### PR TITLE
Simplify keyboard support

### DIFF
--- a/tactility-esp/src/apps/system/wifi_connect/wifi_connect_view.c
+++ b/tactility-esp/src/apps/system/wifi_connect/wifi_connect_view.c
@@ -4,7 +4,6 @@
 #include "lvgl.h"
 #include "services/gui/gui.h"
 #include "services/wifi/wifi_credentials.h"
-#include "ui/lvgl_keypad.h"
 #include "ui/spacer.h"
 #include "ui/style.h"
 #include "wifi_connect.h"
@@ -114,7 +113,7 @@ void wifi_connect_view_create(App app, void* wifi, lv_obj_t* parent) {
 }
 
 void wifi_connect_view_destroy(TT_UNUSED WifiConnectView* view) {
-    tt_lvgl_keypad_deactivate();
+    // NO-OP
 }
 
 void wifi_connect_view_update(

--- a/tactility-esp/src/apps/system/wifi_connect/wifi_connect_view.c
+++ b/tactility-esp/src/apps/system/wifi_connect/wifi_connect_view.c
@@ -13,15 +13,6 @@
 
 #define TAG "wifi_connect"
 
-static void show_keyboard(lv_event_t* event) {
-    gui_keyboard_show(event->current_target);
-    lv_obj_scroll_to_view(event->current_target, LV_ANIM_ON);
-}
-
-static void hide_keyboard(TT_UNUSED lv_event_t* event) {
-    gui_keyboard_hide();
-}
-
 static void on_connect(lv_event_t* event) {
     WifiConnect* wifi = (WifiConnect*)event->user_data;
     WifiConnectView* view = &wifi->view;
@@ -104,14 +95,8 @@ void wifi_connect_view_create(App app, void* wifi, lv_obj_t* parent) {
 
     wifi_connect_view_create_bottom_buttons(wifi, parent);
 
-    if (gui_keyboard_is_enabled()) {
-        lv_obj_add_event_cb(view->ssid_textarea, show_keyboard, LV_EVENT_FOCUSED, NULL);
-        lv_obj_add_event_cb(view->ssid_textarea, hide_keyboard, LV_EVENT_DEFOCUSED, NULL);
-        lv_obj_add_event_cb(view->ssid_textarea, hide_keyboard, LV_EVENT_READY, NULL);
-        lv_obj_add_event_cb(view->password_textarea, show_keyboard, LV_EVENT_FOCUSED, NULL);
-        lv_obj_add_event_cb(view->password_textarea, hide_keyboard, LV_EVENT_DEFOCUSED, NULL);
-        lv_obj_add_event_cb(view->password_textarea, hide_keyboard, LV_EVENT_READY, NULL);
-    }
+    gui_keyboard_add_textarea(view->ssid_textarea);
+    gui_keyboard_add_textarea(view->password_textarea);
 
     // Init from app parameters
     Bundle* _Nullable bundle = tt_app_get_parameters(app);
@@ -126,18 +111,10 @@ void wifi_connect_view_create(App app, void* wifi, lv_obj_t* parent) {
             lv_textarea_set_text(view->password_textarea, password);
         }
     }
-
-    // Hardware keyboard("keypad") requires a group
-    view->group = lv_group_create();
-    lv_group_add_obj(view->group, view->ssid_textarea);
-    lv_group_add_obj(view->group, view->password_textarea);
-    tt_lvgl_keypad_activate(view->group);
 }
 
 void wifi_connect_view_destroy(TT_UNUSED WifiConnectView* view) {
-    // Cleanup keypad group
     tt_lvgl_keypad_deactivate();
-    lv_group_del(view->group);
 }
 
 void wifi_connect_view_update(

--- a/tactility/src/hardware.c
+++ b/tactility/src/hardware.c
@@ -1,5 +1,7 @@
-#include "check.h"
 #include "hardware_i.h"
+
+#include "check.h"
+#include "lvgl.h"
 
 #define TAG "hardware"
 

--- a/tactility/src/services/gui/gui.h
+++ b/tactility/src/services/gui/gui.h
@@ -34,26 +34,26 @@ void gui_hide_app();
 void gui_keyboard_show(lv_obj_t* textarea);
 
 /**
- * Attach automatic hide/show parameters for the keyboard.
- * Also registers the textarea to the default lv_group_t for hardware keyboards.
- * @param textarea
- */
-void gui_keyboard_add_textarea(lv_obj_t* textarea);
-
-/**
  * Hide the on-screen keyboard.
  * Has no effect when the keyboard is not visible.
  */
 void gui_keyboard_hide();
 
 /**
- * This function is to facilitate hardware keyboards like the one on Lilygo T-Deck.
- * The software keyboard is only shown when both of these conditions are true:
+ * The on-screen keyboard is only shown when both of these conditions are true:
  *  - there is no hardware keyboard
  *  - TT_CONFIG_FORCE_ONSCREEN_KEYBOARD is set to true in tactility_config.h
- * @return if we should show a keyboard for text input inside our apps
+ * @return if we should show a on-screen keyboard for text input inside our apps
  */
 bool gui_keyboard_is_enabled();
+
+/**
+ * Glue code for the on-screen keyboard and the hardware keyboard:
+ *  - Attach automatic hide/show parameters for the on-screen keyboard.
+ *  - Registers the textarea to the default lv_group_t for hardware keyboards.
+ * @param textarea
+ */
+void gui_keyboard_add_textarea(lv_obj_t* textarea);
 
 #ifdef __cplusplus
 }

--- a/tactility/src/services/gui/gui.h
+++ b/tactility/src/services/gui/gui.h
@@ -34,6 +34,13 @@ void gui_hide_app();
 void gui_keyboard_show(lv_obj_t* textarea);
 
 /**
+ * Attach automatic hide/show parameters for the keyboard.
+ * Also registers the textarea to the default lv_group_t for hardware keyboards.
+ * @param textarea
+ */
+void gui_keyboard_add_textarea(lv_obj_t* textarea);
+
+/**
  * Hide the on-screen keyboard.
  * Has no effect when the keyboard is not visible.
  */

--- a/tactility/src/services/gui/gui_draw.c
+++ b/tactility/src/services/gui/gui_draw.c
@@ -49,8 +49,12 @@ static lv_obj_t* create_app_views(Gui* gui, lv_obj_t* parent, App app) {
     lv_obj_set_width(child_container, LV_PCT(100));
     lv_obj_set_flex_grow(child_container, 1);
 
-    gui->keyboard = lv_keyboard_create(vertical_container);
-    lv_obj_add_flag(gui->keyboard, LV_OBJ_FLAG_HIDDEN);
+    if (gui_keyboard_is_enabled()) {
+        gui->keyboard = lv_keyboard_create(vertical_container);
+        lv_obj_add_flag(gui->keyboard, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        gui->keyboard = NULL;
+    }
 
     return child_container;
 }

--- a/tactility/src/services/gui/gui_i.h
+++ b/tactility/src/services/gui/gui_i.h
@@ -30,14 +30,11 @@ struct Gui {
     lv_group_t* keyboard_group;
 };
 
-/** Update GUI, request redraw
- */
+/** Update GUI, request redraw */
 void gui_request_draw();
 
-/** Lock GUI
- */
+/** Lock GUI */
 void gui_lock();
 
-/** Unlock GUI
- */
+/** Unlock GUI */
 void gui_unlock();

--- a/tactility/src/services/gui/gui_i.h
+++ b/tactility/src/services/gui/gui_i.h
@@ -27,6 +27,7 @@ struct Gui {
 
     lv_obj_t* _Nullable toolbar;
     lv_obj_t* _Nullable keyboard;
+    lv_group_t* keyboard_group;
 };
 
 /** Update GUI, request redraw

--- a/tactility/src/services/gui/gui_keyboard.c
+++ b/tactility/src/services/gui/gui_keyboard.c
@@ -1,0 +1,70 @@
+#include "gui_i.h"
+
+#include "tactility_config.h"
+#include "ui/lvgl_keypad.h"
+#include "ui/lvgl_sync.h"
+
+extern Gui* gui;
+
+static void show_keyboard(lv_event_t* event) {
+    gui_keyboard_show(event->current_target);
+    lv_obj_scroll_to_view(event->current_target, LV_ANIM_ON);
+}
+
+static void hide_keyboard(TT_UNUSED lv_event_t* event) {
+    gui_keyboard_hide();
+}
+
+bool gui_keyboard_is_enabled() {
+    return !tt_lvgl_keypad_is_available() || TT_CONFIG_FORCE_ONSCREEN_KEYBOARD;
+}
+
+void gui_keyboard_show(lv_obj_t* textarea) {
+    gui_lock();
+
+    if (gui->keyboard) {
+        gui_lock();
+
+        lv_obj_clear_flag(gui->keyboard, LV_OBJ_FLAG_HIDDEN);
+        lv_keyboard_set_textarea(gui->keyboard, textarea);
+
+        if (gui->toolbar) {
+            lv_obj_add_flag(gui->toolbar, LV_OBJ_FLAG_HIDDEN);
+        }
+
+    }
+
+    gui_unlock();
+}
+
+void gui_keyboard_hide() {
+    gui_lock();
+
+    if (gui->keyboard) {
+        lv_obj_add_flag(gui->keyboard, LV_OBJ_FLAG_HIDDEN);
+        if (gui->toolbar) {
+            lv_obj_clear_flag(gui->toolbar, LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+
+    gui_unlock();
+}
+
+void gui_keyboard_add_textarea(lv_obj_t* textarea) {
+    gui_lock();
+    tt_check(tt_lvgl_lock(0), "lvgl should already be locked before calling this method");
+
+    if (gui_keyboard_is_enabled()) {
+        lv_obj_add_event_cb(textarea, show_keyboard, LV_EVENT_FOCUSED, NULL);
+        lv_obj_add_event_cb(textarea, hide_keyboard, LV_EVENT_DEFOCUSED, NULL);
+        lv_obj_add_event_cb(textarea, hide_keyboard, LV_EVENT_READY, NULL);
+    }
+
+    // lv_obj_t auto-remove themselves from the group when they are destroyed (last checked in LVGL 8.3)
+    lv_group_add_obj(gui->keyboard_group, textarea);
+
+    tt_lvgl_keypad_activate(gui->keyboard_group);
+
+    tt_lvgl_unlock();
+    gui_unlock();
+}

--- a/tactility/src/tactility.c
+++ b/tactility/src/tactility.c
@@ -84,7 +84,7 @@ TT_UNUSED void tt_init(const Config* config) {
     tt_hardware_init(config->hardware);
 
     // Note: the order of starting apps and services is critical!
-    // System services are registered first so they can be used by the apps
+    // System services are registered first so the apps below can use them
     register_and_start_system_services();
     // Then we register system apps. They are not used/started yet.
     register_system_apps();

--- a/tactility/src/ui/lvgl_keypad.h
+++ b/tactility/src/ui/lvgl_keypad.h
@@ -1,3 +1,6 @@
+/**
+ * This code relates to the hardware keyboard support also known as "keypads" in LVGL.
+ */
 #pragma once
 
 #include "lvgl.h"
@@ -6,9 +9,28 @@
 extern "C" {
 #endif
 
+/**
+ * @return true if LVGL is configured with a keypad
+ */
 bool tt_lvgl_keypad_is_available();
+
+/**
+ * Set the keypad.
+ * @param device the keypad device
+ */
 void tt_lvgl_keypad_set_indev(lv_indev_t* device);
+
+/**
+ * Activate the keypad for a widget group.
+ * @param group
+ */
 void tt_lvgl_keypad_activate(lv_group_t* group);
+
+/**
+ * Deactivate the keypad for the current widget group (if any).
+ * You don't have to call this after calling _activate() because widget
+ * cleanup automatically removes itself from the group it belongs to.
+ */
 void tt_lvgl_keypad_deactivate();
 
 #ifdef __cplusplus


### PR DESCRIPTION
I introduced `gui_keyboard_add_textarea()` which automatically registers for events to show/hide the software keyboard.
It also adds the textareas to a special group: this is required for the hardware keyboard to work.

Other changes:
- Ignore software keyboard creation when the software keyboard is disabled
- Created `gui_keyboard.c` with all keyboard-related functionality