### PR TITLE
Revert to ESP-IDF v5.2

### DIFF
--- a/.github/workflows/esp.yml
+++ b/.github/workflows/esp.yml
@@ -13,7 +13,7 @@ jobs:
       - name: build
         uses: espressif/esp-idf-ci-action@main
         with:
-          esp_idf_version: v5.3.1
+          esp_idf_version: v5.2.3
           target: esp32
           path: './'
   build-lilygo-t-deck:
@@ -28,7 +28,7 @@ jobs:
       - name: build
         uses: espressif/esp-idf-ci-action@main
         with:
-          esp_idf_version: v5.3.1
+          esp_idf_version: v5.2.3
           target: esp32s3
           path: './'
   build-waveshare-s3-touch:
@@ -43,7 +43,7 @@ jobs:
       - name: build
         uses: espressif/esp-idf-ci-action@main
         with:
-          esp_idf_version: v5.3.1
+          esp_idf_version: v5.2.3
           target: esp32s3
           path: './'
   build-m5stack-core2:
@@ -58,6 +58,6 @@ jobs:
       - name: build
         uses: espressif/esp-idf-ci-action@main
         with:
-          esp_idf_version: v5.3.1
+          esp_idf_version: v5.2.3
           target: esp32
           path: './'

--- a/app-esp/idf_component.yml
+++ b/app-esp/idf_component.yml
@@ -3,4 +3,4 @@ dependencies:
   espressif/esp_lcd_touch_cst816s: "1.0.3"
   espressif/esp_lcd_touch_gt911: "1.1.1"
   espressif/esp_lcd_touch: "1.1.2"
-  idf: '~5.3.1'
+  idf: '~5.2'

--- a/tactility/CMakeLists.txt
+++ b/tactility/CMakeLists.txt
@@ -9,7 +9,7 @@ if (DEFINED ENV{ESP_IDF_VERSION})
     idf_component_register(
         SRCS ${SOURCE_FILES}
         INCLUDE_DIRS "src/"
-        REQUIRES tactility-headless lvgl esp_driver_gpio
+        REQUIRES tactility-headless lvgl driver
     )
 
     target_link_libraries(${COMPONENT_LIB}


### PR DESCRIPTION
The rendering of M5Core2 was broken with IDF v5.3, so I'm reverting that change for now.
It wasn't noticed before because there's a chance that it boots normally without glitching. The glitch were horizontal distorted lines every 40-60 pixels. There was also a vertical shift downward of the rendering.