### PR TITLE
Introduce touch offset to M5Stack Core2

### DIFF
--- a/boards/m5stack_core2/source/touch.cpp
+++ b/boards/m5stack_core2/source/touch.cpp
@@ -8,12 +8,18 @@
 extern "C" {
 #endif
 
+/**
+ * Touch seems to be offset by a certain amount.
+ * The docs don't mention it, so this is the estimated value.
+ */
+#define TOUCH_Y_OFFSET 16
+
 static void read_touch(TT_UNUSED lv_indev_t* indev, lv_indev_data_t* data) {
     lgfx::touch_point_t point; // Making it static makes it unreliable
     bool touched = M5.Lcd.getTouch(&point) > 0;
     if (touched) {
         data->point.x = point.x;
-        data->point.y = point.y;
+        data->point.y = point.y - TOUCH_Y_OFFSET;
         data->state = LV_INDEV_STATE_PRESSED;
     } else {
         data->state = LV_INDEV_STATE_RELEASED;


### PR DESCRIPTION
Touch seems to be offset, but it's not clear from the docs by how much. It likely has something to do with the touch area under the LCD area.
I can't measure the actual offset with a pointing device currently, so the current offset is estimated.