### PR TITLE
Use Bundle consistently

### DIFF
--- a/sdkconfig.md
+++ b/sdkconfig.md
@@ -1,0 +1,20 @@
+# Get Started
+
+Copy the relevant `sdkconfig.board.*` file into `sdkconfig`.
+This will apply the relevant settings to build the project for your hardware.
+
+# Useful Parameters
+
+## Enable FPS
+
+```
+CONFIG_LV_USE_OBSERVER=y
+CONFIG_LV_USE_PERF_MONITOR=y
+```
+
+## Halt on error
+
+```
+CONFIG_ESP_SYSTEM_PANIC_PRINT_HALT=y
+# CONFIG_ESP_SYSTEM_PANIC_PRINT_REBOOT is not set
+```

--- a/tactility-headless/src/preferences_memory.c
+++ b/tactility-headless/src/preferences_memory.c
@@ -5,9 +5,9 @@
 #include <string.h>
 #include <tactility_core.h>
 
-static Bundle* preferences_bundle;
+static Bundle preferences_bundle;
 
-static Bundle* get_preferences_bundle() {
+static Bundle get_preferences_bundle() {
     if (preferences_bundle == NULL) {
         preferences_bundle = tt_bundle_alloc();
     }

--- a/tactility/src/app.c
+++ b/tactility/src/app.c
@@ -13,7 +13,7 @@ static const AppFlags DEFAULT_FLAGS = {
 
 // region Alloc/free
 
-App tt_app_alloc(const AppManifest* manifest, Bundle* _Nullable parameters) {
+App tt_app_alloc(const AppManifest* manifest, Bundle _Nullable parameters) {
 #ifdef ESP_PLATFORM
     size_t memory_before = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
 #else
@@ -132,10 +132,10 @@ void tt_app_set_data(App app, void* value) {
  * Consider creating MutableBundle vs Bundle.
  * Consider not exposing bundle, but expose `app_get_bundle_int(key)` methods with locking in it.
  */
-Bundle* _Nullable tt_app_get_parameters(App app) {
+Bundle _Nullable tt_app_get_parameters(App app) {
     AppData* data = (AppData*)app;
     tt_app_lock(data);
-    Bundle* bundle = data->parameters;
+    Bundle bundle = data->parameters;
     tt_app_unlock(data);
     return bundle;
 }

--- a/tactility/src/app.h
+++ b/tactility/src/app.h
@@ -29,7 +29,7 @@ typedef void* App;
  * @param parameters optional bundle. memory ownership is transferred to App
  * @return
  */
-App tt_app_alloc(const AppManifest* manifest, Bundle* _Nullable parameters);
+App tt_app_alloc(const AppManifest* manifest, Bundle _Nullable parameters);
 void tt_app_free(App app);
 
 void tt_app_set_state(App app, AppState state);
@@ -43,7 +43,7 @@ void tt_app_set_flags(App app, AppFlags flags);
 void* _Nullable tt_app_get_data(App app);
 void tt_app_set_data(App app, void* data);
 
-Bundle* _Nullable tt_app_get_parameters(App app);
+Bundle _Nullable tt_app_get_parameters(App app);
 
 #ifdef __cplusplus
 }

--- a/tactility/src/app_i.h
+++ b/tactility/src/app_i.h
@@ -21,7 +21,7 @@ typedef struct {
      * When these are stored in the app struct, the struct takes ownership.
      * Do not mutate after app creation.
      */
-    Bundle* _Nullable parameters;
+    Bundle _Nullable parameters;
     /** @brief @brief Contextual data related to the running app's instance
      * The app can attach its data to this.
      * The lifecycle is determined by the on_start and on_stop methods in the AppManifest.

--- a/tactility/src/apps/wifi_connect/wifi_connect_view.c
+++ b/tactility/src/apps/wifi_connect/wifi_connect_view.c
@@ -98,7 +98,7 @@ void wifi_connect_view_create(App app, void* wifi, lv_obj_t* parent) {
     gui_keyboard_add_textarea(view->password_textarea);
 
     // Init from app parameters
-    Bundle* _Nullable bundle = tt_app_get_parameters(app);
+    Bundle _Nullable bundle = tt_app_get_parameters(app);
     if (bundle) {
         char* ssid;
         if (tt_bundle_opt_string(bundle, WIFI_CONNECT_PARAM_SSID, &ssid)) {

--- a/tactility/src/services/loader/loader.c
+++ b/tactility/src/services/loader/loader.c
@@ -66,7 +66,7 @@ void loader_unlock() {
     tt_check(tt_mutex_release(loader_singleton->mutex) == TtStatusOk);
 }
 
-LoaderStatus loader_start_app(const char* id, bool blocking, Bundle* _Nullable bundle) {
+LoaderStatus loader_start_app(const char* id, bool blocking, Bundle _Nullable bundle) {
     tt_check(loader_singleton);
     LoaderMessageLoaderStatusResult result = {
         .value = LoaderStatusOk
@@ -184,7 +184,7 @@ static void app_transition_to_state(App app, AppState state) {
 
 LoaderStatus loader_do_start_app_with_manifest(
     const AppManifest* manifest,
-    Bundle* _Nullable bundle
+    Bundle _Nullable bundle
 ) {
     TT_LOG_I(TAG, "start with manifest %s", manifest->id);
 
@@ -230,7 +230,7 @@ LoaderStatus loader_do_start_app_with_manifest(
 
 static LoaderStatus loader_do_start_by_id(
     const char* id,
-    Bundle* _Nullable bundle
+    Bundle _Nullable bundle
 ) {
     TT_LOG_I(TAG, "Start by id %s", id);
 

--- a/tactility/src/services/loader/loader.h
+++ b/tactility/src/services/loader/loader.h
@@ -59,7 +59,7 @@ typedef struct {
  * @param[in] bundle optional bundle. Ownership is transferred to Loader.
  * @return LoaderStatus
  */
-LoaderStatus loader_start_app(const char* id, bool blocking, Bundle* _Nullable bundle);
+LoaderStatus loader_start_app(const char* id, bool blocking, Bundle _Nullable bundle);
 
 /**
  * @brief Stop the currently showing app. Show the previous app if any app was still running.

--- a/tactility/src/services/loader/loader_i.h
+++ b/tactility/src/services/loader/loader_i.h
@@ -36,7 +36,7 @@ typedef enum {
 
 typedef struct {
     const char* id;
-    Bundle* _Nullable bundle;
+    Bundle _Nullable bundle;
 } LoaderMessageAppStart;
 
 typedef struct {


### PR DESCRIPTION
`Bundle*` and `Bundle` were used intermittently.
Change to proper usage: `Bundle`.

\+ added `sdkconfig.md`