### PR TITLE
Implemented app result and more

### DIFF
--- a/Documentation/ideas.md
+++ b/Documentation/ideas.md
@@ -15,15 +15,14 @@
 - Bug: in LVGL9 with M5Core2, crash when bottom item is clicked without scrolling first
 - Publish firmwares with upload tool
 - De-duplicate WiFi SSIDs.
-- Refactor hardware configuration init methods to return esp_err_t instead of bool
 - Replace M5Unified and M5GFX with custom drivers (so we can fix the Core2 SD card mounting bug, and so we regain some firmware space)
 
 # Core Ideas
 - Support for displays with different DPI. Consider the layer-based system like on Android.
 - If present, use LED to show boot status
 - 2 wire speaker support
-- tt::startApp() and similar functions as proxies for Loader app start/stop/etc.
-- tt::setAppResult() for apps that need to return data to other apps (e.g. file selection)
+- tt::app::start() and similar functions as proxies for Loader app start/stop/etc.
+- App.setResult() for apps that need to return data to other apps (e.g. file selection)
 - Wi-Fi using dispatcher to dispatch its main functionality to the dedicated Wi-Fi CPU core (to avoid main loop hack)
 
 # App Ideas

--- a/Tactility/Private/app/AppInstance.h
+++ b/Tactility/Private/app/AppInstance.h
@@ -4,6 +4,7 @@
 #include "app/Manifest.h"
 #include "Bundle.h"
 #include "Mutex.h"
+#include <memory>
 
 namespace tt::app {
 
@@ -14,6 +15,20 @@ typedef enum {
     StateHiding,  // App view is destroyed
     StateStopped  // App is not in memory
 } State;
+
+struct ResultHolder {
+    ResultHolder(Result result, const Bundle& resultData) {
+        this->result = result;
+        this->resultData = new Bundle(resultData);
+    }
+
+    ~ResultHolder() {
+        delete resultData;
+    }
+
+    Result result;
+    Bundle* _Nullable resultData;
+};
 
 /**
  * Thread-safe app instance.
@@ -37,6 +52,7 @@ private:
      * These manifest methods can optionally allocate/free data that is attached here.
      */
     void* _Nullable data = nullptr;
+    std::unique_ptr<ResultHolder> resultHolder;
 
 public:
 
@@ -61,6 +77,10 @@ public:
     void setData(void* data);
 
     const Bundle& getParameters() const;
+
+    void setResult(Result result, const Bundle& bundle);
+    bool hasResult() const;
+    std::unique_ptr<ResultHolder>& getResult() { return resultHolder; }
 };
 
 } // namespace

--- a/Tactility/Source/Tactility.cpp
+++ b/Tactility/Source/Tactility.cpp
@@ -44,6 +44,7 @@ namespace app {
     namespace display { extern const Manifest manifest; }
     namespace i2csettings { extern const Manifest manifest; }
     namespace power { extern const Manifest manifest; }
+    namespace selectiondialog { extern const Manifest manifest; }
     namespace systeminfo { extern const Manifest manifest; }
     namespace textviewer { extern const Manifest manifest; }
     namespace wificonnect { extern const Manifest manifest; }
@@ -62,6 +63,7 @@ static const std::vector<const app::Manifest*> system_apps = {
     &app::i2csettings::manifest,
     &app::imageviewer::manifest,
     &app::settings::manifest,
+    &app::selectiondialog::manifest,
     &app::systeminfo::manifest,
     &app::textviewer::manifest,
     &app::wificonnect::manifest,

--- a/Tactility/Source/app/App.h
+++ b/Tactility/Source/app/App.h
@@ -24,6 +24,7 @@ public:
     virtual void setData(void* data) = 0;
     virtual const Bundle& getParameters() const = 0;
     virtual Flags getFlags() const = 0;
+    virtual void setResult(Result result, const Bundle& bundle = Bundle()) = 0;
 };
 
 }

--- a/Tactility/Source/app/AppInstance.cpp
+++ b/Tactility/Source/app/AppInstance.cpp
@@ -57,4 +57,9 @@ const Bundle& AppInstance::getParameters() const {
     return parameters;
 }
 
+void AppInstance::setResult(Result result, const Bundle& bundle) {
+    std::unique_ptr<ResultHolder> new_holder(new ResultHolder(result, bundle));
+    resultHolder = std::move(new_holder);
+}
+
 } // namespace

--- a/Tactility/Source/app/Manifest.h
+++ b/Tactility/Source/app/Manifest.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <Bundle.h>
 #include "CoreDefines.h"
 
 // Forward declarations
@@ -23,11 +24,17 @@ typedef enum {
     TypeUser
 } Type;
 
+typedef enum {
+    ResultOk,
+    ResultCancelled,
+    ResultError
+} Result;
 
 typedef void (*AppOnStart)(App& app);
 typedef void (*AppOnStop)(App& app);
 typedef void (*AppOnShow)(App& app, lv_obj_t* parent);
 typedef void (*AppOnHide)(App& app);
+typedef void (*AppOnResult)(App& app, Result result, const Bundle& resultData);
 
 typedef struct Manifest {
     /**
@@ -43,7 +50,7 @@ typedef struct Manifest {
     /**
      * Optional icon.
      */
-    std::string icon = {};
+    std::string icon;
 
     /**
      * App type affects launch behaviour.
@@ -69,7 +76,12 @@ typedef struct Manifest {
      * Non-blocking method, called before gui is destroyed
      */
     const AppOnHide _Nullable onHide = nullptr;
-} AppManifest;
+
+    /**
+     * Handle the result for apps that are launched
+     */
+    const AppOnResult _Nullable onResult = nullptr;
+} Manifest;
 
 struct {
     bool operator()(const Manifest* left, const Manifest* right) const { return left->name < right->name; }

--- a/Tactility/Source/app/selectiondialog/SelectionDialog.cpp
+++ b/Tactility/Source/app/selectiondialog/SelectionDialog.cpp
@@ -1,0 +1,109 @@
+#include "SelectionDialog.h"
+#include "Log.h"
+#include "lvgl.h"
+#include "lvgl/Toolbar.h"
+#include "service/loader/Loader.h"
+#include <StringUtils.h>
+
+namespace tt::app::selectiondialog {
+
+#define PARAMETER_BUNDLE_KEY_TITLE "title"
+#define PARAMETER_BUNDLE_KEY_ITEMS "items"
+#define RESULT_BUNDLE_KEY_INDEX "index"
+
+#define PARAMETER_ITEM_CONCATENATION_TOKEN ";;"
+#define DEFAULT_TITLE "Select..."
+
+#define TAG "selection_dialog"
+
+void setItemsParameter(Bundle& bundle, const std::vector<std::string>& items) {
+    std::string result = string_join(items, PARAMETER_ITEM_CONCATENATION_TOKEN);
+    bundle.putString(PARAMETER_BUNDLE_KEY_ITEMS, result);
+}
+
+int32_t getResultIndex(const Bundle& bundle) {
+    int32_t index = -1;
+    bundle.optInt32(RESULT_BUNDLE_KEY_INDEX, index);
+    return index;
+}
+
+void setResultIndex(Bundle& bundle, int32_t index) {
+    bundle.putInt32(RESULT_BUNDLE_KEY_INDEX, index);
+}
+
+void setTitleParameter(Bundle& bundle, const std::string& title) {
+    bundle.putString(PARAMETER_BUNDLE_KEY_TITLE, title);
+}
+
+static std::string getTitleParameter(const Bundle& bundle) {
+    std::string result;
+    if (bundle.optString(PARAMETER_BUNDLE_KEY_TITLE, result)) {
+        return result;
+    } else {
+        return DEFAULT_TITLE;
+    }
+}
+
+static void onListItemSelected(lv_event_t* e) {
+    lv_event_code_t code = lv_event_get_code(e);
+    if (code == LV_EVENT_CLICKED) {
+        size_t index = (size_t)(e->user_data);
+        TT_LOG_I(TAG, "Selected item at index %d", index);
+        tt::app::App* app = service::loader::get_current_app();
+        Bundle bundle;
+        setResultIndex(bundle, (int32_t)index);
+        app->setResult(app::ResultOk, bundle);
+        service::loader::stop_app();
+    }
+}
+
+static void createChoiceItem(void* parent, const std::string& title, size_t index) {
+    auto* list = static_cast<lv_obj_t*>(parent);
+    lv_obj_t* btn = lv_list_add_button(list, nullptr, title.c_str());
+    lv_obj_add_event_cb(btn, &onListItemSelected, LV_EVENT_CLICKED, (void*)index);
+}
+
+static void onShow(App& app, lv_obj_t* parent) {
+    lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_COLUMN);
+    std::string title = getTitleParameter(app.getParameters());
+    lvgl::toolbar_create(parent, title);
+
+    lv_obj_t* list = lv_list_create(parent);
+    lv_obj_set_width(list, LV_PCT(100));
+    lv_obj_set_flex_grow(list, 1);
+
+    const Bundle& parameters = app.getParameters();
+    std::string items_concatenated;
+    if (parameters.optString(PARAMETER_BUNDLE_KEY_ITEMS, items_concatenated)) {
+        std::vector<std::string> items = string_split(items_concatenated, PARAMETER_ITEM_CONCATENATION_TOKEN);
+        if (items.empty() || items.front().empty()) {
+            TT_LOG_E(TAG, "No items provided");
+            app.setResult(ResultError);
+            service::loader::stop_app();
+        } else if (items.size() == 1) {
+            Bundle result_bundle;
+            setResultIndex(result_bundle, 0);
+            app.setResult(ResultOk, result_bundle);
+            service::loader::stop_app();
+            TT_LOG_W(TAG, "Auto-selecting single item");
+        } else {
+            size_t index = 0;
+            for (const auto& item: items) {
+                createChoiceItem(list, item, index++);
+            }
+        }
+    } else {
+        TT_LOG_E(TAG, "No items provided");
+        app.setResult(ResultError);
+        service::loader::stop_app();
+    }
+}
+
+extern const Manifest manifest = {
+     .id = "SelectionDialog",
+     .name = "Selection Dialog",
+     .type = TypeHidden,
+     .onShow = &onShow
+};
+
+}

--- a/Tactility/Source/app/selectiondialog/SelectionDialog.h
+++ b/Tactility/Source/app/selectiondialog/SelectionDialog.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "Bundle.h"
+
+/**
+ * Start the app by its ID and provide:
+ *  - an optional title
+ *  - 2 or more items
+ *
+ *  If you provide 0 items, the app will auto-close.
+ *  If you provide 1 item, the app will auto-close with result index 0
+ */
+namespace tt::app::selectiondialog {
+
+    /** App startup parameters */
+
+    void setTitleParameter(Bundle& bundle, const std::string& title);
+    void setItemsParameter(Bundle& bundle, const std::vector<std::string>& items);
+
+    /** App result data */
+
+    int32_t getResultIndex(const Bundle& bundle);
+}

--- a/Tactility/Source/lvgl/Toolbar.cpp
+++ b/Tactility/Source/lvgl/Toolbar.cpp
@@ -83,13 +83,13 @@ lv_obj_t* toolbar_create(lv_obj_t* parent, const std::string& title) {
     lv_obj_set_style_pad_all(toolbar->action_container, 0, 0);
     lv_obj_set_style_border_width(toolbar->action_container, 0, 0);
 
+    toolbar_set_nav_action(obj, LV_SYMBOL_CLOSE, &stop_app, nullptr);
+
     return obj;
 }
 
 lv_obj_t* toolbar_create(lv_obj_t* parent, const app::App& app) {
-    lv_obj_t* toolbar = toolbar_create(parent, app.getManifest().name);
-    toolbar_set_nav_action(toolbar, LV_SYMBOL_CLOSE, &stop_app, nullptr);
-    return toolbar;
+    return toolbar_create(parent, app.getManifest().name);
 }
 
 void toolbar_set_title(lv_obj_t* obj, const std::string& title) {

--- a/TactilityCore/Source/StringUtils.cpp
+++ b/TactilityCore/Source/StringUtils.cpp
@@ -1,5 +1,7 @@
 #include "StringUtils.h"
 #include <cstring>
+#include <iostream>
+#include <sstream>
 
 namespace tt {
 
@@ -25,6 +27,49 @@ bool string_get_path_parent(const char* path, char* output) {
         output[index] = 0x00;
         return true;
     }
+}
+
+std::vector<std::string> string_split(const std::string&input, const std::string&delimiter) {
+    size_t token_index = 0;
+    size_t delimiter_index;
+    const size_t delimiter_length = delimiter.length();
+    std::string token;
+    std::vector<std::string> result;
+
+    while ((delimiter_index = input.find(delimiter, token_index)) != std::string::npos) {
+        token = input.substr(token_index, delimiter_index - token_index);
+        token_index = delimiter_index + delimiter_length;
+        result.push_back(token);
+    }
+
+    auto end_token = input.substr(token_index);
+    if (!end_token.empty()) {
+        result.push_back(end_token);
+    }
+
+    return result;
+}
+
+std::string string_join(const std::vector<std::string>& input, const std::string& delimiter) {
+    std::stringstream stream;
+    size_t size = input.size();
+
+    if (size == 0) {
+        return "";
+    } else if (size == 1) {
+        return input.front();
+    } else {
+        auto iterator = input.begin();
+        while (iterator != input.end()) {
+            stream << *iterator;
+            iterator++;
+            if (iterator != input.end()) {
+                stream << delimiter;
+            }
+        }
+    }
+
+    return stream.str();
 }
 
 } // namespace

--- a/TactilityCore/Source/StringUtils.h
+++ b/TactilityCore/Source/StringUtils.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdio>
+#include <string>
+#include <vector>
 
 namespace tt {
 
@@ -20,5 +22,24 @@ int string_find_last_index(const char* text, size_t from_index, char find);
  * @return true when successful
  */
 bool string_get_path_parent(const char* path, char* output);
+
+/**
+ * Splits the provided input into separate pieces with delimiter as separator text.
+ * When the input string is empty, the output list will be empty too.
+ *
+ * @param input the input to split up
+ * @param delimiter a non-empty string to recognize as separator
+ */
+std::vector<std::string> string_split(const std::string& input, const std::string& delimiter);
+
+/**
+ * Join a set of tokens into a single string, given a delimiter (separator).
+ * If the input is an empty list, the result will be an empty string.
+ * The delimeter is only placed inbetween tokens and not appended at the end of the resulting string.
+ *
+ * @param input the tokens to join together
+ * @param delimiter the separator to join with
+ */
+std::string string_join(const std::vector<std::string>& input, const std::string& delimiter);
 
 } // namespace

--- a/Tests/TactilityCore/StringTest.cpp
+++ b/Tests/TactilityCore/StringTest.cpp
@@ -1,0 +1,66 @@
+#include "doctest.h"
+#include "StringUtils.h"
+
+using namespace tt;
+using namespace std;
+
+// region string_split
+
+TEST_CASE("splitting an empty string results in an empty vector") {
+    auto result = string_split("", ".");
+    CHECK_EQ(result.empty(), true);
+}
+
+TEST_CASE("splitting a string with a single token results in a vector with that token") {
+    auto result = string_split("token", ".");
+    CHECK_EQ(result.size(), 1);
+    CHECK_EQ(result.front(), "token");
+}
+
+TEST_CASE("splitting a string with multiple tokens results in a vector with those tokens") {
+    auto result = string_split("token1;token2;token3;", ";");
+    CHECK_EQ(result.size(), 3);
+    CHECK_EQ(result[0], "token1");
+    CHECK_EQ(result[1], "token2");
+    CHECK_EQ(result[2], "token3");
+}
+
+// endregion string_split
+
+// region string_join
+
+TEST_CASE("joining an empty vector results in an empty string") {
+    vector<string> tokens = {};
+    auto result = string_join(tokens, ".");
+    CHECK_EQ(result, "");
+}
+
+TEST_CASE("joining a single token results in a string with that value") {
+    vector<string> tokens = {
+        "token"
+    };
+    auto result = string_join(tokens, ".");
+    CHECK_EQ(result, "token");
+}
+
+TEST_CASE("joining multiple tokens results in a string with all the tokens and the delimiter") {
+    vector<string> tokens = {
+        "token1",
+        "token2",
+        "token3",
+    };
+    auto result = string_join(tokens, ".");
+    CHECK_EQ(result, "token1.token2.token3");
+}
+
+TEST_CASE("joining with empty tokens leads to an extra delimiter") {
+    vector<string> tokens = {
+     "token1",
+     "",
+     "token2",
+    };
+    auto result = string_join(tokens, ".");
+    CHECK_EQ(result, "token1..token2");
+}
+
+// endregion string_join


### PR DESCRIPTION
- When an app launches another app, they can observe result values, so:
- Apps can now set a result value before they stop
- Added split and join string in `StringUtils`, including tests
- Created `SelectionDialog` app that allows for the creation of generic list selection (and it returns the resulting index)