### PR TITLE
Include SDL as subproject to fix CI simulator build

### DIFF
--- a/.github/workflows/pc.yml
+++ b/.github/workflows/pc.yml
@@ -9,17 +9,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: libsdl-org/setup-sdl@main
-        id: sdl
-        with:
-          install-linux-dependencies: true
-          version: 2-latest
-          version-sdl-image: 2-latest
       - name: Configure Project
         uses: threeal/cmake-action@v2.0.0
       - name: Prepare Project
         run: cmake -S ./ -B build
       - name: Build Project
-        env:
-          USE_SDL_WITH_NAMESPACE: true
         run: cmake --build build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ on: [push]
 jobs:
   Run:
     runs-on: ubuntu-latest
-    env:
-      SKIP_SDL: true
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "Libraries/lvgl"]
 	path = Libraries/lvgl
 	url = https://github.com/lvgl/lvgl.git
+[submodule "Libraries/SDL"]
+	path = Libraries/SDL
+	url = https://github.com/libsdl-org/SDL.git

--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -24,7 +24,6 @@ if (DEFINED ENV{ESP_IDF_VERSION})
     )
 else()
 
-
     file(GLOB_RECURSE SOURCES "Source/*.c*")
     add_executable(AppSim ${SOURCES})
     target_link_libraries(AppSim
@@ -32,13 +31,8 @@ else()
         PRIVATE TactilityCore
         PRIVATE TactilityHeadless
         PRIVATE Simulator
+        PRIVATE SDL2::SDL2-static SDL2-static
     )
-
-    if (NOT DEFINED ENV{SKIP_SDL})
-        find_package(SDL2 REQUIRED CONFIG)
-        include_directories(${SDL2_INCLUDE_DIRS})
-        target_link_libraries(AppSim PRIVATE ${SDL2_LIBRARIES})
-    endif()
 
     add_definitions(-D_Nullable=)
     add_definitions(-D_Nonnull=)

--- a/Boards/Simulator/CMakeLists.txt
+++ b/Boards/Simulator/CMakeLists.txt
@@ -17,13 +17,10 @@ if (NOT DEFINED ENV{ESP_IDF_VERSION})
         PRIVATE TactilityCore
         PRIVATE TactilityHeadless
         PRIVATE lvgl
-        PRIVATE ${SDL2_LIBRARIES}
+        PRIVATE SDL2-static
     )
 
-    if (NOT DEFINED ENV{SKIP_SDL})
-        find_package(SDL2 REQUIRED CONFIG)
-        target_link_libraries(Simulator PRIVATE ${SDL2_LIBRARIES})
-    endif()
+    target_link_libraries(Simulator PRIVATE ${SDL2_LIBRARIES})
 
     add_definitions(-D_Nullable=)
     add_definitions(-D_Nonnull=)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ if (NOT DEFINED ENV{ESP_IDF_VERSION})
 endif()
 
 if (NOT DEFINED ENV{ESP_IDF_VERSION})
+
     # FreeRTOS
     set(FREERTOS_CONFIG_FILE_DIRECTORY ${PROJECT_SOURCE_DIR}/Boards/Simulator/Source CACHE STRING "")
     set(FREERTOS_PORT GCC_POSIX CACHE STRING "")
@@ -87,22 +88,19 @@ if (NOT DEFINED ENV{ESP_IDF_VERSION})
     add_subdirectory(Libraries/mbedtls)
 
     # Sim app
-    if (NOT DEFINED ENV{SKIP_SDL})
-        add_subdirectory(App)
-    endif()
+    add_subdirectory(App)
 
     # Tests
     add_subdirectory(Tests)
 
+    # SDL
+    add_compile_definitions($<$<BOOL:${LV_USE_DRAW_SDL}>:LV_USE_DRAW_SDL=1>)
+    add_subdirectory(Libraries/SDL) # Added as idf component for ESP and as library for other targets
+
     # LVGL
     add_subdirectory(Libraries/lvgl) # Added as idf component for ESP and as library for other targets
     include_directories(lvgl PUBLIC ${PROJECT_SOURCE_DIR}/Libraries/lvgl_conf)
-    if (NOT DEFINED ENV{SKIP_SDL})
-        find_package(SDL2 REQUIRED CONFIG)
-        target_include_directories(lvgl PUBLIC ${SDL2_INCLUDE_DIRS})
-        target_link_libraries(lvgl
-            PRIVATE ${SDL2_LIBRARIES}
-        )
-    endif()
     target_compile_definitions(lvgl PUBLIC "-DLV_CONF_PATH=\"${PROJECT_SOURCE_DIR}/Libraries/lvgl_conf/lv_conf_simulator.h\"")
+    target_link_libraries(lvgl PRIVATE SDL2-static)
+
 endif()

--- a/Documentation/ideas.md
+++ b/Documentation/ideas.md
@@ -13,14 +13,9 @@
 - EventFlag: Fix return value of set/get/wait (the errors are weirdly mixed in)
 - Consistently use either ESP_TARGET or ESP_PLATFORM
 - tt_check() failure during app argument bundle nullptr check seems to trigger SIGSEGV
-- Fix bug in T-Deck/etc: esp_lvgl_port settings has a large stack depth (~9kB) to fix an issue where the T-Deck would get a stackoverflow. This sometimes happens when WiFi is auto-enabled and you open the app while it is still connecting.
+- Fix bug in T-Deck/etc: esp_lvgl_port settings has a large stack size (~9kB) to fix an issue where the T-Deck would get a stackoverflow. This sometimes happens when WiFi is auto-enabled and you open the app while it is still connecting.
 
 # TODOs
-- Try to fix SDL pipeline issue with apt-get:
-  ```yaml
-  - name: Install SDL
-    run: sudo apt-get install -y libsdl2-dev cmake
-  ```
 - Make "blocking" argument the last one, and put it default to false (or remove it entirely?): void startApp(const std::string& id, bool blocking, std::shared_ptr<const Bundle> parameters) {
 - Boot hooks instead of a single boot method in config. Define different boot phases/levels in enum.
 - Add toggle to Display app for sysmon overlay: https://docs.lvgl.io/master/API/others/sysmon/index.html

--- a/Libraries/lvgl_conf/lv_conf_simulator.h
+++ b/Libraries/lvgl_conf/lv_conf_simulator.h
@@ -163,7 +163,7 @@
 #define LV_USE_DRAW_DAVE2D 0
 
 /* Draw using cached SDL textures*/
-#define LV_USE_DRAW_SDL 0
+#define LV_USE_DRAW_SDL 1
 
 /* Use VG-Lite GPU. */
 #define LV_USE_DRAW_VG_LITE 0


### PR DESCRIPTION
This is a work-around for a CI build issue:
https://github.com/libsdl-org/setup-sdl/issues/23

It allows for building the simulator in the pipeline again.