### PR TITLE
Thread, Timer and flash.sh improvements

### DIFF
--- a/Boards/LilygoTdeck/Source/Lvgl.cpp
+++ b/Boards/LilygoTdeck/Source/Lvgl.cpp
@@ -14,7 +14,7 @@
 bool tdeck_init_lvgl() {
     static lv_disp_t* display = nullptr;
     const lvgl_port_cfg_t lvgl_cfg = {
-        .task_priority = tt::THREAD_PRIORITY_RENDER,
+        .task_priority = static_cast<UBaseType_t>(tt::THREAD_PRIORITY_RENDER),
         .task_stack = TDECK_LVGL_TASK_STACK_DEPTH,
         .task_affinity = -1, // core pinning
         .task_max_sleep_ms = 500,

--- a/Boards/M5stackCore2/Source/InitLvgl.cpp
+++ b/Boards/M5stackCore2/Source/InitLvgl.cpp
@@ -12,7 +12,7 @@
 
 bool initLvgl() {
     const lvgl_port_cfg_t lvgl_cfg = {
-        .task_priority = tt::THREAD_PRIORITY_RENDER,
+        .task_priority = static_cast<UBaseType_t>(tt::THREAD_PRIORITY_RENDER),
         .task_stack = CORE2_LVGL_TASK_STACK_DEPTH,
         .task_affinity = -1, // core pinning
         .task_max_sleep_ms = 500,

--- a/Boards/M5stackCoreS3/Source/InitLvgl.cpp
+++ b/Boards/M5stackCoreS3/Source/InitLvgl.cpp
@@ -12,7 +12,7 @@
 
 bool initLvgl() {
     const lvgl_port_cfg_t lvgl_cfg = {
-        .task_priority = tt::THREAD_PRIORITY_RENDER,
+        .task_priority = static_cast<UBaseType_t>(tt::THREAD_PRIORITY_RENDER),
         .task_stack = CORE2_LVGL_TASK_STACK_DEPTH,
         .task_affinity = -1, // core pinning
         .task_max_sleep_ms = 500,

--- a/Boards/Simulator/Source/LvglTask.cpp
+++ b/Boards/Simulator/Source/LvglTask.cpp
@@ -65,7 +65,7 @@ void lvgl_task_start() {
         "lvgl",
         8192,
         nullptr,
-        tt::Thread::PriorityHigh, // Should be higher than main app task
+        static_cast<UBaseType_t>(tt::Thread::Priority::High), // Should be higher than main app task
         nullptr
     );
 

--- a/Boards/Simulator/Source/Main.cpp
+++ b/Boards/Simulator/Source/Main.cpp
@@ -29,7 +29,7 @@ void freertosMain() {
         "main",
         8192,
         nullptr,
-        tt::Thread::PriorityNormal,
+        static_cast<UBaseType_t>(tt::Thread::Priority::Normal),
         nullptr
     );
 

--- a/Boards/YellowBoard/Source/Lvgl.cpp
+++ b/Boards/YellowBoard/Source/Lvgl.cpp
@@ -7,7 +7,7 @@
 
 bool twodotfour_lvgl_init() {
     const lvgl_port_cfg_t lvgl_cfg = {
-        .task_priority = tt::THREAD_PRIORITY_RENDER,
+        .task_priority = static_cast<UBaseType_t>(tt::THREAD_PRIORITY_RENDER),
         .task_stack = 8096,
         .task_affinity = -1, // core pinning
         .task_max_sleep_ms = 500,

--- a/Documentation/ideas.md
+++ b/Documentation/ideas.md
@@ -28,12 +28,9 @@
 - Attach ELF data to wrapper app (as app data) (check that app state is "running"!) so you can run more than 1 external apps at a time.
   We'll need to keep track of all manifest instances, so that the wrapper can look up the relevant manifest for the relevant callbacks.
 - T-Deck: Clear screen before turning on blacklight
-- Audio player app
-- Audio recording app
 - T-Deck: Use knob for UI selection
 - Crash monitoring: Keep track of which system phase the app crashed in (e.g. which app in which state)
 - AppContext's onResult should pass the app id (or launch request id!) that was started, so we can differentiate between multiple types of apps being launched
-- Loader: Use main dispatcher instead of Thread
 - Create more unit tests for `tactility-core` and `tactility` (PC-only for now)
 - Show a warning screen if firmware encryption or secure boot are off when saving WiFi credentials.
 - Show a warning screen when a user plugs in the SD card on a device that only supports mounting at boot.
@@ -45,6 +42,8 @@
 - Support hot-plugging SD card
 
 # Nice-to-haves
+- Audio player app
+- Audio recording app
 - OTA updates
 - Web flasher
 - T-Deck Plus: Create separate board config?

--- a/TactilityC/Source/tt_init.cpp
+++ b/TactilityC/Source/tt_init.cpp
@@ -74,8 +74,6 @@ const struct esp_elfsym elf_symbols[] {
     ESP_ELFSYM_EXPORT(tt_thread_alloc_ext),
     ESP_ELFSYM_EXPORT(tt_thread_free),
     ESP_ELFSYM_EXPORT(tt_thread_set_name),
-    ESP_ELFSYM_EXPORT(tt_thread_mark_as_static),
-    ESP_ELFSYM_EXPORT(tt_thread_is_marked_as_static),
     ESP_ELFSYM_EXPORT(tt_thread_set_stack_size),
     ESP_ELFSYM_EXPORT(tt_thread_set_callback),
     ESP_ELFSYM_EXPORT(tt_thread_set_priority),

--- a/TactilityC/Source/tt_thread.cpp
+++ b/TactilityC/Source/tt_thread.cpp
@@ -31,14 +31,6 @@ void tt_thread_set_name(ThreadHandle handle, const char* name) {
     HANDLE_AS_THREAD(handle)->setName(name);
 }
 
-void tt_thread_mark_as_static(ThreadHandle handle) {
-    HANDLE_AS_THREAD(handle)->markAsStatic();
-}
-
-bool tt_thread_is_marked_as_static(ThreadHandle handle) {
-    return HANDLE_AS_THREAD(handle)->isMarkedAsStatic();
-}
-
 void tt_thread_set_stack_size(ThreadHandle handle, size_t size) {
     HANDLE_AS_THREAD(handle)->setStackSize(size);
 }

--- a/TactilityC/Source/tt_thread.h
+++ b/TactilityC/Source/tt_thread.h
@@ -38,14 +38,14 @@ typedef int32_t (*ThreadCallback)(void* context);
 typedef void (*ThreadStateCallback)(ThreadState state, void* context);
 
 typedef enum {
-    ThreadPriorityNone = 0, /**< Uninitialized, choose system default */
-    ThreadPriorityIdle = 1,
-    ThreadPriorityLowest = 2,
-    ThreadPriorityLow = 3,
-    ThreadPriorityNormal = 4,
-    ThreadPriorityHigh = 5,
-    ThreadPriorityHigher = 6,
-    ThreadPriorityHighest = 7
+    ThreadPriorityNone = 0U, /**< Uninitialized, choose system default */
+    ThreadPriorityIdle = 1U,
+    ThreadPriorityLowest = 2U,
+    ThreadPriorityLow = 3U,
+    ThreadPriorityNormal = 4U,
+    ThreadPriorityHigh = 5U,
+    ThreadPriorityHigher = 6U,
+    ThreadPriorityHighest = 7U
 } ThreadPriority;
 
 ThreadHandle tt_thread_alloc();
@@ -57,8 +57,6 @@ ThreadHandle tt_thread_alloc_ext(
 );
 void tt_thread_free(ThreadHandle handle);
 void tt_thread_set_name(ThreadHandle handle, const char* name);
-void tt_thread_mark_as_static(ThreadHandle handle);
-bool tt_thread_is_marked_as_static(ThreadHandle handle);
 void tt_thread_set_stack_size(ThreadHandle handle, size_t size);
 void tt_thread_set_callback(ThreadHandle handle, ThreadCallback callback, void* _Nullable callbackContext);
 void tt_thread_set_priority(ThreadHandle handle, ThreadPriority priority);

--- a/TactilityC/Source/tt_timer.cpp
+++ b/TactilityC/Source/tt_timer.cpp
@@ -58,8 +58,8 @@ bool tt_timer_set_pending_callback(TimerHandle handle, TimerPendingCallback call
     );
 }
 
-void tt_timer_set_thread_priority(TimerHandle handle, TimerThreadPriority priority) {
-    ((TimerWrapper*)handle)->timer->setThreadPriority((tt::Timer::ThreadPriority)priority);
+void tt_timer_set_thread_priority(TimerHandle handle, ThreadPriority priority) {
+    ((TimerWrapper*)handle)->timer->setThreadPriority((tt::Thread::Priority)priority);
 }
 
 }

--- a/TactilityC/Source/tt_timer.h
+++ b/TactilityC/Source/tt_timer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "tt_thread.h"
 #include <freertos/FreeRTOS.h>
 
 #ifdef __cplusplus
@@ -16,11 +17,6 @@ typedef enum {
     TimerTypePeriodic = 1 ///< Repeating timer.
 } TimerType;
 
-typedef enum {
-    TimerThreadPriorityNormal,   /**< Lower then other threads */
-    TimerThreadPriorityElevated, /**< Same as other threads */
-} TimerThreadPriority;
-
 typedef void (*TimerCallback)(void* context);
 typedef void (*TimerPendingCallback)(void* context, uint32_t arg);
 
@@ -32,7 +28,7 @@ bool tt_timer_stop(TimerHandle handle);
 bool tt_timer_is_running(TimerHandle handle);
 uint32_t tt_timer_get_expire_time(TimerHandle handle);
 bool tt_timer_set_pending_callback(TimerHandle handle, TimerPendingCallback callback, void* callbackContext, uint32_t callbackArg, TickType_t timeoutTicks);
-void tt_timer_set_thread_priority(TimerHandle handle, TimerThreadPriority priority);
+void tt_timer_set_thread_priority(TimerHandle handle, ThreadPriority priority);
 
 #ifdef __cplusplus
 }

--- a/TactilityCore/Source/DispatcherThread.cpp
+++ b/TactilityCore/Source/DispatcherThread.cpp
@@ -18,7 +18,7 @@ DispatcherThread::DispatcherThread(const std::string& threadName, size_t threadS
 }
 
 DispatcherThread::~DispatcherThread() {
-    if (thread->getState() != Thread::StateStopped) {
+    if (thread->getState() != Thread::State::Stopped) {
         stop();
     }
 }

--- a/TactilityCore/Source/Timer.h
+++ b/TactilityCore/Source/Timer.h
@@ -3,6 +3,7 @@
 #include "CoreTypes.h"
 
 #include "RtosCompatTimers.h"
+#include "Thread.h"
 #include <memory>
 
 namespace tt {
@@ -34,17 +35,17 @@ public:
 
     /** Start timer
      * @warning This is asynchronous call, real operation will happen as soon as timer service process this request.
-     * @param[in] ticks The interval in ticks
+     * @param[in] interval The interval in ticks
      * @return success result
      */
-    bool start(uint32_t intervalTicks);
+    bool start(TickType_t interval);
 
     /** Restart timer with previous timeout value
      * @warning This is asynchronous call, real operation will happen as soon as timer service process this request.
-     * @param[in] ticks The interval in ticks
+     * @param[in] interval The interval in ticks
      * @return success result
      */
-    bool restart(uint32_t intervalTicks);
+    bool restart(TickType_t interval);
 
     /** Stop timer
      * @warning This is asynchronous call, real operation will happen as soon as timer service process this request.
@@ -61,7 +62,7 @@ public:
     /** Get timer expire time
      * @return expire tick
      */
-    uint32_t getExpireTime();
+    TickType_t getExpireTime();
 
     /**
      * Calls xTimerPendFunctionCall internally.
@@ -69,18 +70,19 @@ public:
      * @param[in] callbackContext the first function argument
      * @param[in] callbackArg the second function argument
      * @param[in] timeout the function timeout (must set to 0 in ISR mode)
+     * @return true on success
      */
     bool setPendingCallback(PendingCallback callback, void* callbackContext, uint32_t callbackArg, TickType_t timeout);
 
-    typedef enum {
-        TimerThreadPriorityNormal,   /**< Lower then other threads */
-        TimerThreadPriorityElevated, /**< Same as other threads */
-    } ThreadPriority;
+    enum class Priority{
+        Normal,   /**< Lower then other threads */
+        Elevated, /**< Same as other threads */
+    };
 
     /** Set Timer thread priority
      * @param[in] priority The priority
      */
-    void setThreadPriority(ThreadPriority priority);
+    void setThreadPriority(Thread::Priority priority);
 };
 
 } // namespace

--- a/Tests/TactilityCore/MutexTest.cpp
+++ b/Tests/TactilityCore/MutexTest.cpp
@@ -23,12 +23,12 @@ TEST_CASE("a mutex can block a thread") {
     thread.start();
 
     kernel::delayMillis(5);
-    CHECK_EQ(thread.getState(), Thread::StateRunning);
+    CHECK_EQ(thread.getState(), Thread::State::Running);
 
     mutex.unlock();
 
     kernel::delayMillis(5);
-    CHECK_EQ(thread.getState(), Thread::StateStopped);
+    CHECK_EQ(thread.getState(), Thread::State::Stopped);
 
     thread.join();
 }

--- a/Tests/TactilityCore/ThreadTest.cpp
+++ b/Tests/TactilityCore/ThreadTest.cpp
@@ -78,13 +78,13 @@ TEST_CASE("thread state should be correct") {
         &interruptable_thread,
         &interrupted
     );
-    CHECK_EQ(thread->getState(), Thread::StateStopped);
+    CHECK_EQ(thread->getState(), Thread::State::Stopped);
     thread->start();
     Thread::State state = thread->getState();
-    CHECK((state == Thread::StateStarting || state == Thread::StateRunning));
+    CHECK((state == Thread::State::Starting || state == Thread::State::Running));
     interrupted = true;
     thread->join();
-    CHECK_EQ(thread->getState(), Thread::StateStopped);
+    CHECK_EQ(thread->getState(), Thread::State::Stopped);
     delete thread;
 }
 


### PR DESCRIPTION
- Various improvements to Thread and Timer:
  - Remove "mark as static" option as it is unused
  - Implemented core pinning for ESP32 platforms
  - Use `TickType_t` consistently (instead of `uint32_t`)
  - Use `enum class` instead of `enum`
- Fix for `flash.sh` not working when using `pip` to install `esptool`