### PR TITLE
Unphone improvements

### DIFF
--- a/Boards/UnPhone/Source/PowerOn.cpp
+++ b/Boards/UnPhone/Source/PowerOn.cpp
@@ -64,23 +64,21 @@ static bool unPhonePowerOn() {
 
     unPhoneFeatures.printInfo();
 
+    // Vibrate once
+    // Note: Do this before power switching logic, to detect silent boot loops
+    unPhoneFeatures.setVibePower(true);
+    tt::kernel::delayMillis(150);
+    unPhoneFeatures.setVibePower(false);
+
+    // Turn off the device if power switch is on off state,
+    // instead of waiting for the Thread to start and continue booting
     updatePowerSwitch();
     startPowerSwitchThread();
 
     unPhoneFeatures.setBacklightPower(false);
-
-    // Init touch screen GPIOs (used for vibe motor)
     unPhoneFeatures.setVibePower(false);
-
     unPhoneFeatures.setIrPower(false);
-
-    // This will be default LOW implicitly, but this makes it explicit
     unPhoneFeatures.setExpanderPower(false);
-
-    // Vibrate once
-    unPhoneFeatures.setVibePower(true);
-    tt::kernel::delayMillis(150);
-    unPhoneFeatures.setVibePower(false);
 
     return true;
 }

--- a/Documentation/ideas.md
+++ b/Documentation/ideas.md
@@ -16,6 +16,7 @@
 - Fix bug in T-Deck/etc: esp_lvgl_port settings has a large stack size (~9kB) to fix an issue where the T-Deck would get a stackoverflow. This sometimes happens when WiFi is auto-enabled and you open the app while it is still connecting.
 - M5Stack Core only shows 4MB of SPIRAM in use
 - Try to improve Core2 and CoreS3 performance by setting swap_bytes of display driver to false (this is a software operation on the display buffer!) and use 24 bit colour mode if needed
+- Files app: When SD card is not mounted, don't show it
 
 # TODOs
 - Boards' CMakeLists.txt manually declare each source folder. Update them all to do a recursive search of all folders.


### PR DESCRIPTION
- Debounce nav button presses: This fixes multiple triggers on a single press to navigate back. Otherwise, more than 1 app would often close at the same time.
- Nav button respond to release instead of push down, because these buttons aren't super reliable in general. (I might change this in the future after more testing)
- Move single buzz earlier in boot phase, so that we can detect silent boot loops.