### PR TITLE
Various fixes and improvements

### DIFF
--- a/Boards/UnPhone/Source/UnPhoneFeatures.cpp
+++ b/Boards/UnPhone/Source/UnPhoneFeatures.cpp
@@ -168,12 +168,28 @@ bool UnPhoneFeatures::initGpioExpander() {
     assert(ioExpander != nullptr);
 
     // Output pins
+
+    /**
+     * Important:
+     * If you clear the pins too late, the display or vibration motor might briefly turn on.
+     */
+
     esp_io_expander_set_dir(ioExpander, expanderpin::BACKLIGHT, IO_EXPANDER_OUTPUT);
+    esp_io_expander_set_level(ioExpander, expanderpin::BACKLIGHT, 0);
+
     esp_io_expander_set_dir(ioExpander, expanderpin::EXPANDER_POWER, IO_EXPANDER_OUTPUT);
+
     esp_io_expander_set_dir(ioExpander, expanderpin::LED_GREEN, IO_EXPANDER_OUTPUT);
+    esp_io_expander_set_level(ioExpander, expanderpin::LED_GREEN, 0);
+
     esp_io_expander_set_dir(ioExpander, expanderpin::LED_BLUE, IO_EXPANDER_OUTPUT);
+    esp_io_expander_set_level(ioExpander, expanderpin::LED_BLUE, 0);
+
     esp_io_expander_set_dir(ioExpander, expanderpin::VIBE, IO_EXPANDER_OUTPUT);
+    esp_io_expander_set_level(ioExpander, expanderpin::VIBE, 0);
+
     // Input pins
+
     esp_io_expander_set_dir(ioExpander, expanderpin::USB_VSENSE, IO_EXPANDER_INPUT);
 
     return true;
@@ -266,16 +282,12 @@ void UnPhoneFeatures::turnPeripheralsOff() const {
 bool UnPhoneFeatures::setShipping(bool on) const {
     if (on) {
         TT_LOG_W(TAG, "setShipping: on");
-        uint8_t mask = (1 << 4) | (1 << 5);
-        // REG05[5:4] = 00
-        batteryManagement.setWatchDogBitOff(mask);
+        batteryManagement.setWatchDogTimer(Bq24295::WatchDogTimer::Disabled);
         // Set bit 5 to disable
         batteryManagement.setOperationControlBitOn(1 << 5);
     } else {
         TT_LOG_W(TAG, "setShipping: off");
-        // REG05[5:4] = 01
-        batteryManagement.setWatchDogBitOff(1 << 5);
-        batteryManagement.setWatchDogBitOn(1 << 4);
+        batteryManagement.setWatchDogTimer(Bq24295::WatchDogTimer::Enabled40s);
         // Clear bit 5 to enable
         batteryManagement.setOperationControlBitOff(1 << 5);
     }
@@ -287,10 +299,5 @@ void UnPhoneFeatures::wakeOnPowerSwitch() const {
 }
 
 bool UnPhoneFeatures::isUsbPowerConnected() const {
-    uint8_t status;
-    if (batteryManagement.getStatus(status)) {
-        return (status & 4U) != 0U;
-    } else {
-        return false;
-    }
+    return batteryManagement.isUsbPowerConnected();
 }

--- a/Boards/UnPhone/Source/bq24295/Bq24295.cpp
+++ b/Boards/UnPhone/Source/bq24295/Bq24295.cpp
@@ -8,24 +8,55 @@
  * https://gitlab.com/hamishcunningham/unphonelibrary/-/blob/main/unPhone.h?ref_type=heads
  */
 namespace registers {
-    static const uint8_t WATCHDOG = 0x05U; // Datasheet page 35: Charge end/timer cntrl
+    static const uint8_t CHARGE_TERMINATION = 0x05U; // Datasheet page 35: Charge end/timer cntrl
     static const uint8_t OPERATION_CONTROL = 0x07U; // Datasheet page 37: Misc operation control
     static const uint8_t STATUS = 0x08U; // Datasheet page 38: System status
     static const uint8_t VERSION = 0x0AU; // Datasheet page 38: Vendor/part/revision status
 } // namespace registers
 
+bool Bq24295::readChargeTermination(uint8_t& out) const {
+    return readRegister8(registers::CHARGE_TERMINATION, out);
+}
+
 // region Watchdog
-bool Bq24295::getWatchDog(uint8_t value) const {
-    return readRegister8(registers::WATCHDOG, value);
+bool Bq24295::getWatchDogTimer(WatchDogTimer& out) const {
+    uint8_t value;
+    if (readChargeTermination(value)) {
+        uint8_t relevant_bits = value & (BIT(4) | BIT(5));
+        switch (relevant_bits) {
+            case 0b000000:
+                out = WatchDogTimer::Disabled;
+                return true;
+            case 0b010000:
+                out = WatchDogTimer::Enabled40s;
+                return true;
+            case 0b100000:
+                out = WatchDogTimer::Enabled80s;
+                return true;
+            case 0b110000:
+                out = WatchDogTimer::Enabled160s;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    return false;
 }
 
-bool Bq24295::setWatchDogBitOn(uint8_t mask) const {
-    return bitOn(registers::WATCHDOG, mask);
+bool Bq24295::setWatchDogTimer(WatchDogTimer in) const {
+    uint8_t value;
+    if (readChargeTermination(value)) {
+        uint8_t bits_to_set = 0b00110000 & static_cast<uint8_t>(in);
+        uint8_t value_cleared = value & 0b11001111;
+        uint8_t to_set = bits_to_set & value_cleared;
+        TT_LOG_I(TAG, "WatchDogTimer: %02x -> %02x", value, to_set);
+        return writeRegister8(registers::CHARGE_TERMINATION, to_set);
+    }
+
+    return false;
 }
 
-bool Bq24295::setWatchDogBitOff(uint8_t mask) const {
-    return bitOff(registers::WATCHDOG, mask);
-}
 
 // endregoin
 
@@ -51,14 +82,23 @@ bool Bq24295::getStatus(uint8_t& value) const {
     return readRegister8(registers::STATUS, value);
 }
 
+bool Bq24295::isUsbPowerConnected() const {
+    uint8_t status;
+    if (getStatus(status)) {
+        return (status & BIT(2)) != 0U;
+    } else {
+        return false;
+    }
+}
+
 bool Bq24295::getVersion(uint8_t& value) const {
     return readRegister8(registers::VERSION, value);
 }
 
 void Bq24295::printInfo() const {
-    uint8_t version, status;
-    if (getStatus(status) && getVersion(version)) {
-        TT_LOG_I(TAG, "Version %d, status %02x", version, status);
+    uint8_t version, status, charge_termination;
+    if (getStatus(status) && getVersion(version) && readChargeTermination(charge_termination)) {
+        TT_LOG_I(TAG, "Version %d, status %02x, charge termination %02x", version, status, charge_termination);
     } else {
         TT_LOG_E(TAG, "Failed to retrieve version and/or status");
     }

--- a/Boards/UnPhone/Source/bq24295/Bq24295.h
+++ b/Boards/UnPhone/Source/bq24295/Bq24295.h
@@ -6,13 +6,25 @@
 
 class Bq24295 : I2cDevice {
 
+private:
+
+    bool readChargeTermination(uint8_t& out) const;
+
 public:
+
+    enum class WatchDogTimer {
+        Disabled = 0b000000,
+        Enabled40s = 0b010000,
+        Enabled80s = 0b100000,
+        Enabled160s = 0b110000
+    };
 
     explicit Bq24295(i2c_port_t port) : I2cDevice(port, BQ24295_ADDRESS) {}
 
-    bool getWatchDog(uint8_t value) const;
-    bool setWatchDogBitOn(uint8_t mask) const;
-    bool setWatchDogBitOff(uint8_t mask) const;
+    bool getWatchDogTimer(WatchDogTimer& out) const;
+    bool setWatchDogTimer(WatchDogTimer in) const;
+
+    bool isUsbPowerConnected() const;
 
     bool getOperationControl(uint8_t value) const;
     bool setOperationControlBitOn(uint8_t mask) const;

--- a/TactilityCore/Source/Mutex.cpp
+++ b/TactilityCore/Source/Mutex.cpp
@@ -46,7 +46,7 @@ Mutex::~Mutex() {
 
 TtStatus Mutex::acquire(TickType_t timeout) const {
     tt_assert(!TT_IS_IRQ_MODE());
-    tt_assert(semaphore);
+    tt_assert(semaphore != nullptr);
 
     tt_mutex_info(mutex, "acquire");
 


### PR DESCRIPTION
- Fix for `logMutex` bug where the `Mutex` constructor is not called when doing early boot logging (with `DEBUG` level logging) . The only way to make it work is to explicitly call the constructor in the logging wrapper function.
- Fix for unPhone power states