### PR TITLE
Refactored manifest onStart/onStop to onCreate/onDestroy

### DIFF
--- a/Tactility/Source/app/App.h
+++ b/Tactility/Source/app/App.h
@@ -38,8 +38,8 @@ public:
     App() = default;
     virtual ~App() = default;
 
-    virtual void onStart(AppContext& appContext) {}
-    virtual void onStop(AppContext& appContext) {}
+    virtual void onCreate(AppContext& appContext) {}
+    virtual void onDestroy(AppContext& appContext) {}
     virtual void onShow(AppContext& appContext, lv_obj_t* parent) {}
     virtual void onHide(AppContext& appContext) {}
     virtual void onResult(AppContext& appContext, Result result, std::unique_ptr<Bundle> _Nullable resultData) {}

--- a/Tactility/Source/app/ElfApp.cpp
+++ b/Tactility/Source/app/ElfApp.cpp
@@ -22,8 +22,8 @@ struct ElfManifest {
     std::string icon;
     CreateData _Nullable createData = nullptr;
     DestroyData _Nullable destroyData = nullptr;
-    OnStart _Nullable onStart = nullptr;
-    OnStop _Nullable onStop = nullptr;
+    OnCreate _Nullable onCreate = nullptr;
+    OnDestroy _Nullable onDestroy = nullptr;
     OnShow _Nullable onShow = nullptr;
     OnHide _Nullable onHide = nullptr;
     OnResult _Nullable onResult = nullptr;
@@ -91,7 +91,7 @@ public:
 
     explicit ElfApp(std::string filePath) : filePath(std::move(filePath)) {}
 
-    void onStart(AppContext& appContext) override {
+    void onCreate(AppContext& appContext) override {
         auto initial_count = elfManifestSetCount;
         if (startElf()) {
             if (elfManifestSetCount > initial_count) {
@@ -101,8 +101,8 @@ public:
                     data = manifest->createData();
                 }
 
-                if (manifest->onStart != nullptr) {
-                    manifest->onStart(&appContext, data);
+                if (manifest->onCreate != nullptr) {
+                    manifest->onCreate(&appContext, data);
                 }
             }
         } else {
@@ -110,11 +110,11 @@ public:
         }
     }
 
-    void onStop(AppContext& appContext) override {
+    void onDestroy(AppContext& appContext) override {
         TT_LOG_I(TAG, "Cleaning up app");
         if (manifest != nullptr) {
-            if (manifest->onStop != nullptr) {
-                manifest->onStop(&appContext, data);
+            if (manifest->onDestroy != nullptr) {
+                manifest->onDestroy(&appContext, data);
             }
 
             if (manifest->destroyData != nullptr && data != nullptr) {
@@ -150,8 +150,8 @@ void setElfAppManifest(
     const char* _Nullable icon,
     CreateData _Nullable createData,
     DestroyData _Nullable destroyData,
-    OnStart _Nullable onStart,
-    OnStop _Nullable onStop,
+    OnCreate _Nullable onCreate,
+    OnDestroy _Nullable onDestroy,
     OnShow _Nullable onShow,
     OnHide _Nullable onHide,
     OnResult _Nullable onResult
@@ -161,8 +161,8 @@ void setElfAppManifest(
         .icon = icon ? icon : "",
         .createData = createData,
         .destroyData = destroyData,
-        .onStart = onStart,
-        .onStop = onStop,
+        .onCreate = onCreate,
+        .onDestroy = onDestroy,
         .onShow = onShow,
         .onHide = onHide,
         .onResult = onResult

--- a/Tactility/Source/app/ElfApp.h
+++ b/Tactility/Source/app/ElfApp.h
@@ -8,8 +8,8 @@ namespace tt::app {
 
 typedef void* (*CreateData)();
 typedef void (*DestroyData)(void* data);
-typedef void (*OnStart)(void* appContext, void* _Nullable data);
-typedef void (*OnStop)(void* appContext, void* _Nullable data);
+typedef void (*OnCreate)(void* appContext, void* _Nullable data);
+typedef void (*OnDestroy)(void* appContext, void* _Nullable data);
 typedef void (*OnShow)(void* appContext, void* _Nullable data, lv_obj_t* parent);
 typedef void (*OnHide)(void* appContext, void* _Nullable data);
 typedef void (*OnResult)(void* appContext, void* _Nullable data, Result result, Bundle* resultData);
@@ -19,8 +19,8 @@ void setElfAppManifest(
     const char* _Nullable icon,
     CreateData _Nullable createData,
     DestroyData _Nullable destroyData,
-    OnStart _Nullable onStart,
-    OnStop _Nullable onStop,
+    OnCreate _Nullable onCreate,
+    OnDestroy _Nullable onDestroy,
     OnShow _Nullable onShow,
     OnHide _Nullable onHide,
     OnResult _Nullable onResult

--- a/Tactility/Source/app/boot/Boot.cpp
+++ b/Tactility/Source/app/boot/Boot.cpp
@@ -97,7 +97,7 @@ public:
         }
     }
 
-    void onStop(AppContext& app) override {
+    void onDestroy(AppContext& app) override {
         thread.join();
     }
 };

--- a/Tactility/Source/app/launcher/Launcher.cpp
+++ b/Tactility/Source/app/launcher/Launcher.cpp
@@ -47,7 +47,7 @@ static lv_obj_t* createAppButton(lv_obj_t* parent, const char* title, const char
 
 class LauncherApp : public App {
 
-    void onStart(TT_UNUSED AppContext& app) override {
+    void onCreate(TT_UNUSED AppContext& app) override {
         auto* config = tt::getConfiguration();
         if (!config->autoStartAppId.empty()) {
             TT_LOG_I(TAG, "auto-starting %s", config->autoStartAppId.c_str());

--- a/Tactility/Source/app/timezone/TimeZone.cpp
+++ b/Tactility/Source/app/timezone/TimeZone.cpp
@@ -231,7 +231,7 @@ public:
         listWidget = list;
     }
 
-    void onStart(AppContext& app) override {
+    void onCreate(AppContext& app) override {
         updateTimer = std::make_unique<Timer>(Timer::Type::Once, updateTimerCallback, nullptr);
     }
 };

--- a/Tactility/Source/service/loader/Loader.cpp
+++ b/Tactility/Source/service/loader/Loader.cpp
@@ -118,7 +118,7 @@ static void transitionAppToState(std::shared_ptr<app::AppInstance> app, app::Sta
         case Initial:
             break;
         case Started:
-            app->getApp()->onStart(*app);
+            app->getApp()->onCreate(*app);
             break;
         case Showing: {
             LoaderEvent event_showing = { .type = LoaderEventTypeApplicationShowing };
@@ -132,7 +132,7 @@ static void transitionAppToState(std::shared_ptr<app::AppInstance> app, app::Sta
         }
         case Stopped:
             // TODO: Verify manifest
-            app->getApp()->onStop(*app);
+            app->getApp()->onDestroy(*app);
             break;
     }
 

--- a/TactilityC/Source/tt_app_manifest.cpp
+++ b/TactilityC/Source/tt_app_manifest.cpp
@@ -24,7 +24,7 @@ void tt_app_register(
         (tt::app::OnResult)manifest->onResult
     );
 #else
-    tt_crash("TactilityC is intended for PC/Simulator");
+    tt_crash("TactilityC is not intended for PC/Simulator");
 #endif
 }
 

--- a/TactilityC/Source/tt_app_manifest.cpp
+++ b/TactilityC/Source/tt_app_manifest.cpp
@@ -17,8 +17,8 @@ void tt_app_register(
         manifest->icon,
         (tt::app::CreateData)manifest->createData,
         (tt::app::DestroyData)manifest->destroyData,
-        (tt::app::OnStart)manifest->onStart,
-        (tt::app::OnStop)manifest->onStop,
+        (tt::app::OnCreate)manifest->onCreate,
+        (tt::app::OnDestroy)manifest->onDestroy,
         (tt::app::OnShow)manifest->onShow,
         (tt::app::OnHide)manifest->onHide,
         (tt::app::OnResult)manifest->onResult

--- a/TactilityC/Source/tt_app_manifest.h
+++ b/TactilityC/Source/tt_app_manifest.h
@@ -19,8 +19,8 @@ typedef void* AppHandle;
 /** Important: These function types must map to t::app types exactly */
 typedef void* (*AppCreateData)();
 typedef void (*AppDestroyData)(void* data);
-typedef void (*AppOnStart)(AppHandle app, void* _Nullable data);
-typedef void (*AppOnStop)(AppHandle app, void* _Nullable data);
+typedef void (*AppOnCreate)(AppHandle app, void* _Nullable data);
+typedef void (*AppOnDestroy)(AppHandle app, void* _Nullable data);
 typedef void (*AppOnShow)(AppHandle app, void* _Nullable data, lv_obj_t* parent);
 typedef void (*AppOnHide)(AppHandle app, void* _Nullable data);
 typedef void (*AppOnResult)(AppHandle app, void* _Nullable data, Result result, BundleHandle resultData);
@@ -35,9 +35,9 @@ typedef struct {
     /** If createData is specified, this one must be specified too */
     AppDestroyData _Nullable destroyData;
     /** Called when the app is launched (started) */
-    AppOnStart _Nullable onStart;
+    AppOnCreate _Nullable onCreate;
     /** Called when the app is exited (stopped) */
-    AppOnStop _Nullable onStop;
+    AppOnDestroy _Nullable onDestroy;
     /** Called when the app is about to be shown to the user (app becomes visible) */
     AppOnShow _Nullable onShow;
     /** Called when the app is about to be invisible to the user (e.g. other app was launched by this app, and this app goes to the background) */


### PR DESCRIPTION
When writing documentation, I realized how `onStart`/`onStop` isn't clearly communicating what it does (it could imply show/hide), so I renamed it to `onCreate` and `onDestroy`.