### PR TITLE
Implement device management

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,5 +19,7 @@ jobs:
         run: cmake -S ./ -B build
       - name: "Build Tests"
         run: cmake --build build --target build-tests
-      - name: "Run Tests"
+      - name: "Run TactilityCore Tests"
         run: build/Tests/TactilityCore/TactilityCoreTests --exit
+      - name: "Run TactilityHeadless Tests"
+        run: build/Tests/TactilityHeadless/TactilityHeadlessTests --exit

--- a/Boards/CYD-2432S024C/Source/hal/YellowDisplay.cpp
+++ b/Boards/CYD-2432S024C/Source/hal/YellowDisplay.cpp
@@ -205,10 +205,10 @@ void YellowDisplay::setGammaCurve(uint8_t index) {
     }
 }
 
-tt::hal::Touch* _Nullable YellowDisplay::createTouch() {
-    return static_cast<tt::hal::Touch*>(new YellowTouch());
+std::shared_ptr<tt::hal::Touch> _Nullable YellowDisplay::createTouch() {
+    return std::make_shared<YellowTouch>();
 }
 
-tt::hal::Display* createDisplay() {
-    return static_cast<tt::hal::Display*>(new YellowDisplay());
+std::shared_ptr<tt::hal::Display> createDisplay() {
+    return std::make_shared<YellowDisplay>();
 }

--- a/Boards/CYD-2432S024C/Source/hal/YellowDisplay.h
+++ b/Boards/CYD-2432S024C/Source/hal/YellowDisplay.h
@@ -16,11 +16,14 @@ private:
 
 public:
 
+    std::string getName() const final { return "ILI9341"; }
+    std::string getDescription() const final { return "SPI display"; }
+
     bool start() override;
 
     bool stop() override;
 
-    tt::hal::Touch* _Nullable createTouch() override;
+    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() override;
 
     void setBacklightDuty(uint8_t backlightDuty) override;
     bool supportsBacklightDuty() const override { return true; }
@@ -31,4 +34,4 @@ public:
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
 };
 
-tt::hal::Display* createDisplay();
+std::shared_ptr<tt::hal::Display> createDisplay();

--- a/Boards/CYD-2432S024C/Source/hal/YellowTouch.h
+++ b/Boards/CYD-2432S024C/Source/hal/YellowTouch.h
@@ -5,12 +5,20 @@
 #include <esp_lcd_touch.h>
 
 class YellowTouch : public tt::hal::Touch {
+
 private:
+
     esp_lcd_panel_io_handle_t ioHandle = nullptr;
     esp_lcd_touch_handle_t touchHandle = nullptr;
     lv_indev_t* _Nullable deviceHandle = nullptr;
+
     void cleanup();
+
 public:
+
+    std::string getName() const final { return "CST816S"; }
+    std::string getDescription() const final { return "I2C touch driver"; }
+
     bool start(lv_display_t* display) override;
     bool stop() override;
     lv_indev_t* _Nullable getLvglIndev() override { return deviceHandle; }

--- a/Boards/LilygoTdeck/Source/hal/TdeckDisplay.cpp
+++ b/Boards/LilygoTdeck/Source/hal/TdeckDisplay.cpp
@@ -191,8 +191,8 @@ void TdeckDisplay::setPowerOn(bool turnOn) {
     }
 }
 
-tt::hal::Touch* _Nullable TdeckDisplay::createTouch() {
-    return static_cast<tt::hal::Touch*>(new TdeckTouch());
+std::shared_ptr<tt::hal::Touch> _Nullable TdeckDisplay::createTouch() {
+    return std::make_shared<TdeckTouch>();
 }
 
 void TdeckDisplay::setBacklightDuty(uint8_t backlightDuty) {
@@ -233,6 +233,6 @@ void TdeckDisplay::setGammaCurve(uint8_t index) {
     }
 }
 
-tt::hal::Display* createDisplay() {
-    return static_cast<tt::hal::Display*>(new TdeckDisplay());
+std::shared_ptr<tt::hal::Display> createDisplay() {
+    return std::make_shared<TdeckDisplay>();
 }

--- a/Boards/LilygoTdeck/Source/hal/TdeckDisplay.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckDisplay.h
@@ -17,6 +17,9 @@ private:
 
 public:
 
+    std::string getName() const final { return "ST7780"; }
+    std::string getDescription() const final { return "SPI display"; }
+
     bool start() override;
 
     bool stop() override;
@@ -25,7 +28,7 @@ public:
     bool isPoweredOn() const override { return poweredOn; };
     bool supportsPowerControl() const override { return true; }
 
-    tt::hal::Touch* _Nullable createTouch() override;
+    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() override;
 
     void setBacklightDuty(uint8_t backlightDuty) override;
     bool supportsBacklightDuty() const override { return true; }
@@ -40,4 +43,4 @@ private:
     static bool startBacklight();
 };
 
-tt::hal::Display* createDisplay();
+std::shared_ptr<tt::hal::Display> createDisplay();

--- a/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.cpp
+++ b/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.cpp
@@ -62,6 +62,6 @@ bool TdeckKeyboard::isAttached() const {
     return tt::hal::i2c::masterHasDeviceAtAddress(TDECK_KEYBOARD_I2C_BUS_HANDLE, TDECK_KEYBOARD_SLAVE_ADDRESS, 100);
 }
 
-tt::hal::Keyboard* createKeyboard() {
-    return dynamic_cast<tt::hal::Keyboard*>(new TdeckKeyboard());
+std::shared_ptr<tt::hal::Keyboard> createKeyboard() {
+    return std::make_shared<TdeckKeyboard>();
 }

--- a/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.h
@@ -6,13 +6,20 @@
 #include <esp_lcd_touch.h>
 
 class TdeckKeyboard : public tt::hal::Keyboard {
+
 private:
+
     lv_indev_t* _Nullable deviceHandle = nullptr;
+
 public:
+
+    std::string getName() const final { return "T-Deck Keyboard"; }
+    std::string getDescription() const final { return "I2C keyboard"; }
+
     bool start(lv_display_t* display) override;
     bool stop() override;
     bool isAttached() const override;
     lv_indev_t* _Nullable getLvglIndev() override { return deviceHandle; }
 };
 
-tt::hal::Keyboard* createKeyboard();
+std::shared_ptr<tt::hal::Keyboard> createKeyboard();

--- a/Boards/LilygoTdeck/Source/hal/TdeckPower.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckPower.h
@@ -15,6 +15,9 @@ public:
     TdeckPower();
     ~TdeckPower();
 
+    std::string getName() const final { return "ADC Power Measurement"; }
+    std::string getDescription() const final { return "Power measurement interface via ADC pin"; }
+
     bool supportsMetric(MetricType type) const override;
     bool getMetric(Power::MetricType type, Power::MetricData& data) override;
 

--- a/Boards/LilygoTdeck/Source/hal/TdeckTouch.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckTouch.h
@@ -6,12 +6,19 @@
 #include <esp_lcd_touch.h>
 
 class TdeckTouch : public tt::hal::Touch {
+
 private:
+
+    std::string getName() const final { return "GT911"; }
+    std::string getDescription() const final { return "I2C Touch Driver"; }
+
     esp_lcd_panel_io_handle_t _Nullable ioHandle = nullptr;
     esp_lcd_touch_handle_t _Nullable touchHandle = nullptr;
     lv_indev_t* _Nullable deviceHandle = nullptr;
     void cleanup();
+
 public:
+
     bool start(lv_display_t* display) override;
     bool stop() override;
     lv_indev_t* _Nullable getLvglIndev() override { return deviceHandle; }

--- a/Boards/M5stackCore2/Source/hal/Core2Display.cpp
+++ b/Boards/M5stackCore2/Source/hal/Core2Display.cpp
@@ -153,10 +153,10 @@ void Core2Display::setGammaCurve(uint8_t index) {
     }
 }
 
-tt::hal::Touch* _Nullable Core2Display::createTouch() {
-    return static_cast<tt::hal::Touch*>(new Core2Touch());
+std::shared_ptr<tt::hal::Touch> _Nullable Core2Display::createTouch() {
+    return std::make_shared<Core2Touch>();
 }
 
-tt::hal::Display* createDisplay() {
-    return static_cast<tt::hal::Display*>(new Core2Display());
+std::shared_ptr<tt::hal::Display> createDisplay() {
+    return std::make_shared<Core2Display>();
 }

--- a/Boards/M5stackCore2/Source/hal/Core2Display.h
+++ b/Boards/M5stackCore2/Source/hal/Core2Display.h
@@ -17,11 +17,14 @@ private:
 
 public:
 
+    std::string getName() const final { return "ILI9342C"; }
+    std::string getDescription() const final { return "Display (ILI9342C with an ILI9341 driver)"; }
+
     bool start() override;
 
     bool stop() override;
 
-    tt::hal::Touch* _Nullable createTouch() override;
+    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() override;
 
     bool supportsBacklightDuty() const override { return false; }
 
@@ -31,4 +34,4 @@ public:
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
 };
 
-tt::hal::Display* createDisplay();
+std::shared_ptr<tt::hal::Display> createDisplay();

--- a/Boards/M5stackCore2/Source/hal/Core2Power.h
+++ b/Boards/M5stackCore2/Source/hal/Core2Power.h
@@ -12,6 +12,9 @@ public:
     Core2Power() = default;
     ~Core2Power() override = default;
 
+    std::string getName() const final { return "AXP192 Power"; }
+    std::string getDescription() const final { return "Power management via I2C"; }
+
     bool supportsMetric(MetricType type) const override;
     bool getMetric(Power::MetricType type, Power::MetricData& data) override;
 

--- a/Boards/M5stackCore2/Source/hal/Core2Touch.h
+++ b/Boards/M5stackCore2/Source/hal/Core2Touch.h
@@ -23,6 +23,9 @@ public:
 
     Core2Touch();
 
+    std::string getName() const final { return "FT6336U"; }
+    std::string getDescription() const final { return "I2C touch driver"; }
+
     bool start(lv_display_t* display) override;
     bool stop() override;
 

--- a/Boards/M5stackCoreS3/Source/Aw9523/Aw9523.h
+++ b/Boards/M5stackCoreS3/Source/Aw9523/Aw9523.h
@@ -4,11 +4,14 @@
 
 #define AW9523_ADDRESS 0x58
 
-class Aw9523 : I2cDevice {
+class Aw9523 : public tt::hal::i2c::I2cDevice {
 
 public:
 
     explicit Aw9523(i2c_port_t port) : I2cDevice(port, AW9523_ADDRESS) {}
+
+    std::string getName() const final { return "AW9523"; }
+    std::string getDescription() const final { return "GPIO expander with LED driver and I2C interface."; }
 
     bool readP0(uint8_t& output) const;
     bool readP1(uint8_t& output) const;

--- a/Boards/M5stackCoreS3/Source/Axp2101/Axp2101.h
+++ b/Boards/M5stackCoreS3/Source/Axp2101/Axp2101.h
@@ -9,7 +9,7 @@
  * - https://github.com/m5stack/M5Unified/blob/master/src/utility/AXP2101_Class.cpp
  * - http://file.whycan.com/files/members/6736/AXP2101_Datasheet_V1.0_en_3832.pdf
  */
-class Axp2101 : I2cDevice {
+class Axp2101 final : public tt::hal::i2c::I2cDevice {
 
 public:
 
@@ -20,6 +20,9 @@ public:
     };
 
     explicit Axp2101(i2c_port_t port) : I2cDevice(port, AXP2101_ADDRESS) {}
+
+    std::string getName() const final { return "AXP2101"; }
+    std::string getDescription() const final { return "Power management with I2C interface."; }
 
     bool setRegisters(uint8_t* bytePairs, size_t bytePairsSize) const;
 

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Display.cpp
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Display.cpp
@@ -181,10 +181,10 @@ void CoreS3Display::setBacklightDuty(uint8_t backlightDuty) {
     }
 }
 
-tt::hal::Touch* _Nullable CoreS3Display::createTouch() {
-    return static_cast<tt::hal::Touch*>(new CoreS3Touch());
+std::shared_ptr<tt::hal::Touch> _Nullable CoreS3Display::createTouch() {
+    return std::make_shared<CoreS3Touch>();
 }
 
-tt::hal::Display* createDisplay() {
-    return static_cast<tt::hal::Display*>(new CoreS3Display());
+std::shared_ptr<tt::hal::Display> createDisplay() {
+    return std::make_shared<CoreS3Display>();
 }

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Display.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Display.h
@@ -16,11 +16,14 @@ private:
 
 public:
 
+    std::string getName() const final { return "ILI9342C"; }
+    std::string getDescription() const final { return "Display (ILI9342C with an ILI9341 driver)"; }
+
     bool start() override;
 
     bool stop() override;
 
-    tt::hal::Touch* _Nullable createTouch() override;
+    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() override;
 
     void setBacklightDuty(uint8_t backlightDuty) override;
     bool supportsBacklightDuty() const override { return true; }
@@ -31,4 +34,4 @@ public:
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
 };
 
-tt::hal::Display* createDisplay();
+std::shared_ptr<tt::hal::Display> createDisplay();

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Power.cpp
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Power.cpp
@@ -1,5 +1,4 @@
 #include "CoreS3Power.h"
-#include <Tactility/TactilityCore.h>
 
 #define TAG "core2_power"
 

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Power.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Power.h
@@ -16,6 +16,9 @@ public:
     CoreS3Power() = default;
     ~CoreS3Power() override = default;
 
+    std::string getName() const final { return "AXP2101 Power"; }
+    std::string getDescription() const final { return "Power management via I2C"; }
+
     bool supportsMetric(MetricType type) const override;
     bool getMetric(Power::MetricType type, Power::MetricData& data) override;
 

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Touch.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Touch.h
@@ -5,12 +5,20 @@
 #include <esp_lcd_touch.h>
 
 class CoreS3Touch : public tt::hal::Touch {
+
 private:
+
     esp_lcd_panel_io_handle_t ioHandle = nullptr;
     esp_lcd_touch_handle_t touchHandle = nullptr;
     lv_indev_t* _Nullable deviceHandle = nullptr;
+
     void cleanup();
+
 public:
+
+    std::string getName() const final { return "FT6336U"; }
+    std::string getDescription() const final { return "I2C touch driver"; }
+
     bool start(lv_display_t* display) override;
     bool stop() override;
     lv_indev_t* _Nullable getLvglIndev() override { return deviceHandle; }

--- a/Boards/Simulator/Source/hal/SdlDisplay.h
+++ b/Boards/Simulator/Source/hal/SdlDisplay.h
@@ -2,23 +2,28 @@
 
 #include "SdlTouch.h"
 #include <Tactility/hal/Display.h>
+#include <memory>
 
 extern lv_disp_t* displayHandle;
 
-class SdlDisplay : public tt::hal::Display {
+class SdlDisplay final : public tt::hal::Display {
 public:
+
+    std::string getName() const final { return "SDL Display"; }
+    std::string getDescription() const final { return ""; }
+
     bool start() override {
         return displayHandle != nullptr;
     }
 
     bool stop() override { tt_crash("Not supported"); }
 
-    tt::hal::Touch* _Nullable createTouch() override { return dynamic_cast<tt::hal::Touch*>(new SdlTouch()); }
+    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() override { return std::make_shared<SdlTouch>(); }
 
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
 };
 
-tt::hal::Display* createDisplay() {
-    return static_cast<tt::hal::Display*>(new SdlDisplay());
+std::shared_ptr<tt::hal::Display> createDisplay() {
+    return std::make_shared<SdlDisplay>();
 }
 

--- a/Boards/Simulator/Source/hal/SdlKeyboard.h
+++ b/Boards/Simulator/Source/hal/SdlKeyboard.h
@@ -3,11 +3,15 @@
 #include <Tactility/hal/Keyboard.h>
 #include <Tactility/TactilityCore.h>
 
-class SdlKeyboard : public tt::hal::Keyboard {
+class SdlKeyboard final : public tt::hal::Keyboard {
 private:
     lv_indev_t* _Nullable handle = nullptr;
 
 public:
+
+    std::string getName() const final { return "SDL Keyboard"; }
+    std::string getDescription() const final { return "SDL keyboard device"; }
+
     bool start(lv_display_t* display) override {
         handle = lv_sdl_keyboard_create();
         return handle != nullptr;
@@ -20,6 +24,6 @@ public:
     lv_indev_t* _Nullable getLvglIndev() override { return handle; }
 };
 
-tt::hal::Keyboard* createKeyboard() {
-    return static_cast<tt::hal::Keyboard*>(new SdlKeyboard());
+std::shared_ptr<tt::hal::Keyboard> createKeyboard() {
+    return std::make_shared<SdlKeyboard>();
 }

--- a/Boards/Simulator/Source/hal/SdlTouch.h
+++ b/Boards/Simulator/Source/hal/SdlTouch.h
@@ -3,11 +3,15 @@
 #include <Tactility/hal/Touch.h>
 #include <Tactility/TactilityCore.h>
 
-class SdlTouch : public tt::hal::Touch {
+class SdlTouch final : public tt::hal::Touch {
 private:
     lv_indev_t* _Nullable handle = nullptr;
 
 public:
+
+    std::string getName() const final { return "SDL Pointer"; }
+    std::string getDescription() const final { return "SDL mouse/touch pointer device"; }
+
     bool start(lv_display_t* display) override {
         handle = lv_sdl_mouse_create();
         return handle != nullptr;

--- a/Boards/Simulator/Source/hal/SimulatorPower.h
+++ b/Boards/Simulator/Source/hal/SimulatorPower.h
@@ -5,7 +5,7 @@
 
 using namespace tt::hal;
 
-class SimulatorPower : public Power {
+class SimulatorPower final : public Power {
 
     bool allowedToCharge = false;
 
@@ -13,6 +13,9 @@ public:
 
     SimulatorPower() = default;
     ~SimulatorPower() override = default;
+
+    std::string getName() const final { return "Power Mock"; }
+    std::string getDescription() const final { return ""; }
 
     bool supportsMetric(MetricType type) const override;
     bool getMetric(Power::MetricType type, Power::MetricData& data) override;

--- a/Boards/Simulator/Source/hal/SimulatorSdCard.h
+++ b/Boards/Simulator/Source/hal/SimulatorSdCard.h
@@ -4,16 +4,24 @@
 
 using namespace tt::hal;
 
-class SimulatorSdCard : public SdCard {
+class SimulatorSdCard final : public SdCard {
+
 private:
+
     State state;
+
 public:
+
     SimulatorSdCard() : SdCard(MountBehaviour::AtBoot), state(State::Unmounted) {}
+
+    std::string getName() const final { return "Mock SD Card"; }
+    std::string getDescription() const final { return ""; }
 
     bool mount(const char* mountPath) override {
         state = State::Mounted;
         return true;
     }
+
     bool unmount() override {
         state = State::Unmounted;
         return true;

--- a/Boards/UnPhone/Source/bq24295/Bq24295.h
+++ b/Boards/UnPhone/Source/bq24295/Bq24295.h
@@ -4,13 +4,17 @@
 
 #define BQ24295_ADDRESS 0x6BU
 
-class Bq24295 : I2cDevice {
+class Bq24295 final : public tt::hal::i2c::I2cDevice {
 
 private:
 
     bool readChargeTermination(uint8_t& out) const;
 
 public:
+
+    std::string getName() const final { return "BQ24295"; }
+
+    std::string getDescription() const final { return "I2C-controlled single cell USB charger"; }
 
     enum class WatchDogTimer {
         Disabled = 0b000000,

--- a/Boards/UnPhone/Source/hal/UnPhoneDisplay.cpp
+++ b/Boards/UnPhone/Source/hal/UnPhoneDisplay.cpp
@@ -30,8 +30,8 @@ bool UnPhoneDisplay::start() {
     lv_display_set_color_format(displayHandle, LV_COLOR_FORMAT_NATIVE);
 
     // TODO malloc to use SPIRAM
-    static auto* buffer1 = (uint8_t*)heap_caps_malloc(BUFFER_SIZE, MALLOC_CAP_SPIRAM);
-    static auto* buffer2 = (uint8_t*)heap_caps_malloc(BUFFER_SIZE, MALLOC_CAP_SPIRAM);
+    buffer1 = (uint8_t*)heap_caps_malloc(BUFFER_SIZE, MALLOC_CAP_SPIRAM);
+    buffer2 = (uint8_t*)heap_caps_malloc(BUFFER_SIZE, MALLOC_CAP_SPIRAM);
     assert(buffer1 != nullptr);
     assert(buffer2 != nullptr);
 
@@ -61,13 +61,18 @@ bool UnPhoneDisplay::stop() {
     lv_display_delete(displayHandle);
     displayHandle = nullptr;
 
+    heap_caps_free(buffer1);
+    heap_caps_free(buffer2);
+    buffer1 = nullptr;
+    buffer2 = nullptr;
+
     return true;
 }
 
-tt::hal::Touch* _Nullable UnPhoneDisplay::createTouch() {
-    return static_cast<tt::hal::Touch*>(new UnPhoneTouch());
+std::shared_ptr<tt::hal::Touch> _Nullable UnPhoneDisplay::createTouch() {
+    return std::make_shared<UnPhoneTouch>();
 }
 
-tt::hal::Display* createDisplay() {
-    return static_cast<tt::hal::Display*>(new UnPhoneDisplay());
+std::shared_ptr<tt::hal::Display> createDisplay() {
+    return std::make_shared<UnPhoneDisplay>();
 }

--- a/Boards/UnPhone/Source/hal/UnPhoneDisplay.h
+++ b/Boards/UnPhone/Source/hal/UnPhoneDisplay.h
@@ -11,16 +11,21 @@ class UnPhoneDisplay : public tt::hal::Display {
 private:
 
     lv_display_t* displayHandle = nullptr;
+    uint8_t* buffer1 = nullptr;
+    uint8_t* buffer2 = nullptr;
 
 public:
+
+    std::string getName() const final { return "HX8357"; }
+    std::string getDescription() const final { return "SPI display"; }
 
     bool start() override;
 
     bool stop() override;
 
-    tt::hal::Touch* _Nullable createTouch() override;
+    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() override;
 
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
 };
 
-tt::hal::Display* createDisplay();
+std::shared_ptr<tt::hal::Display> createDisplay();

--- a/Boards/UnPhone/Source/hal/UnPhonePower.h
+++ b/Boards/UnPhone/Source/hal/UnPhonePower.h
@@ -12,6 +12,9 @@ public:
     UnPhonePower() = default;
     ~UnPhonePower() = default;
 
+    std::string getName() const final { return "XPT2046 Power Measurement"; }
+    std::string getDescription() const final { return "Power interface via XPT2046 voltage measurement"; }
+
     bool supportsMetric(MetricType type) const override;
     bool getMetric(Power::MetricType type, Power::MetricData& data) override;
 

--- a/Boards/UnPhone/Source/hal/UnPhoneTouch.h
+++ b/Boards/UnPhone/Source/hal/UnPhoneTouch.h
@@ -18,6 +18,9 @@ private:
 
 public:
 
+    std::string getName() const final { return "XPT2046"; }
+    std::string getDescription() const final { return "I2C touch driver"; }
+
     bool start(lv_display_t* display) override;
     bool stop() override;
     lv_indev_t* _Nullable getLvglIndev() override { return deviceHandle; }

--- a/Buildscripts/runtests.sh
+++ b/Buildscripts/runtests.sh
@@ -3,4 +3,5 @@
 cmake -S ./ -B build-sim
 cmake --build build-sim --target build-tests -j 14
 build-sim/Tests/TactilityCore/TactilityCoreTests --exit
+build-sim/Tests/TactilityHeadless/TactilityHeadlessTests --exit
 

--- a/Documentation/ideas.md
+++ b/Documentation/ideas.md
@@ -1,5 +1,5 @@
 # TODOs
-- Create a base `Driver` object for drives, and a `DriverManager` to find devices
+- Fix system time to not be 1980 (use build year as minimum)
 - Use std::span or string_view in StringUtils https://youtu.be/FRkJCvHWdwQ?t=2754 
 - Fix bug in T-Deck/etc: esp_lvgl_port settings has a large stack size (~9kB) to fix an issue where the T-Deck would get a stackoverflow. This sometimes happens when WiFi is auto-enabled and you open the app while it is still connecting.
 - Clean up static_cast when casting to base class.

--- a/Tactility/Source/app/power/Power.cpp
+++ b/Tactility/Source/app/power/Power.cpp
@@ -4,6 +4,7 @@
 #include "Tactility/lvgl/Toolbar.h"
 #include "Tactility/service/loader/Loader.h"
 
+#include <Tactility/hal/Device.h>
 #include <Tactility/Assets.h>
 #include <Tactility/Tactility.h>
 #include <Tactility/Timer.h>
@@ -33,7 +34,9 @@ class PowerApp : public App {
 private:
 
     Timer update_timer = Timer(Timer::Type::Periodic, &onTimer, nullptr);
-    std::shared_ptr<tt::hal::Power> power = getConfiguration()->hardware->power();
+
+    std::shared_ptr<hal::Power> power;
+
     lv_obj_t* enableLabel = nullptr;
     lv_obj_t* enableSwitch = nullptr;
     lv_obj_t* batteryVoltageLabel = nullptr;
@@ -135,10 +138,18 @@ private:
 
 public:
 
+    void onCreate(AppContext& app) override {
+        power = hal::findFirstDevice<hal::Power>(hal::Device::Type::Power);
+    }
+
     void onShow(AppContext& app, lv_obj_t* parent) override {
         lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_COLUMN);
 
         lvgl::toolbar_create(parent, app);
+
+        if (power == nullptr) {
+            return;
+        }
 
         lv_obj_t* wrapper = lv_obj_create(parent);
         lv_obj_set_width(wrapper, LV_PCT(100));

--- a/Tactility/Source/lvgl/Init.cpp
+++ b/Tactility/Source/lvgl/Init.cpp
@@ -11,14 +11,16 @@
 
 namespace tt::lvgl {
 
-#define TAG "lvglinit"
+#define TAG "lvgl_init"
 
-bool initDisplay(const hal::Configuration& config) {
+static std::shared_ptr<tt::hal::Display> initDisplay(const hal::Configuration& config) {
     assert(config.createDisplay);
-    auto* display = config.createDisplay();
+    auto display = config.createDisplay();
+    assert(display != nullptr);
+
     if (!display->start()) {
         TT_LOG_E(TAG, "Display start failed");
-        return false;
+        return nullptr;
     }
 
     lv_display_t* lvgl_display = display->getLvglDisplay();
@@ -32,17 +34,17 @@ bool initDisplay(const hal::Configuration& config) {
     // esp_lvgl_port users user_data by default, so we have to modify the source
     // this is a check for when we upgrade esp_lvgl_port and forget to modify it again
     assert(existing_display_user_data == nullptr);
-    lv_display_set_user_data(lvgl_display, display);
+    lv_display_set_user_data(lvgl_display, display.get());
 
     lv_display_rotation_t rotation = app::display::getRotation();
     if (rotation != lv_disp_get_rotation(lv_disp_get_default())) {
         lv_disp_set_rotation(lv_disp_get_default(), static_cast<lv_display_rotation_t>(rotation));
     }
 
-    return true;
+    return display;
 }
 
-bool initTouch(hal::Display* display, hal::Touch* touch) {
+static bool initTouch(const std::shared_ptr<hal::Display>& display, const std::shared_ptr<hal::Touch>& touch) {
     TT_LOG_I(TAG, "Touch init");
     assert(display);
     assert(touch);
@@ -54,14 +56,14 @@ bool initTouch(hal::Display* display, hal::Touch* touch) {
     }
 }
 
-bool initKeyboard(hal::Display* display, hal::Keyboard* keyboard) {
+static bool initKeyboard(const std::shared_ptr<hal::Display>& display, const std::shared_ptr<hal::Keyboard>& keyboard) {
     TT_LOG_I(TAG, "Keyboard init");
     assert(display);
     assert(keyboard);
     if (keyboard->isAttached()) {
         if (keyboard->start(display->getLvglDisplay())) {
             lv_indev_t* keyboard_indev = keyboard->getLvglIndev();
-            lv_indev_set_user_data(keyboard_indev, keyboard);
+            lv_indev_set_user_data(keyboard_indev, keyboard.get());
             tt::lvgl::keypad_set_indev(keyboard_indev);
             TT_LOG_I(TAG, "Keyboard started");
             return true;
@@ -85,20 +87,24 @@ void init(const hal::Configuration& config) {
         return;
     }
 
-    if (!initDisplay(config)) {
+    auto display = initDisplay(config);
+    if (display == nullptr) {
         return;
     }
+    hal::registerDevice(display);
 
-    hal::Display* display = getDisplay();
-
-    hal::Touch* touch = display->createTouch();
+    auto touch = display->createTouch();
     if (touch != nullptr) {
+        hal::registerDevice(touch);
         initTouch(display, touch);
     }
 
     if (config.createKeyboard) {
-        hal::Keyboard* keyboard = config.createKeyboard();
-        initKeyboard(display, keyboard);
+        auto keyboard = config.createKeyboard();
+        if (keyboard != nullptr) {
+            hal::registerDevice(keyboard);
+            initKeyboard(display, keyboard);
+        }
     }
 
     TT_LOG_I(TAG, "Finished");

--- a/TactilityCore/Source/Lockable.cpp
+++ b/TactilityCore/Source/Lockable.cpp
@@ -3,8 +3,7 @@
 namespace tt {
 
 std::unique_ptr<ScopedLockableUsage> Lockable::scoped() const {
-    auto* scoped = new ScopedLockableUsage(*this);
-    return std::unique_ptr<ScopedLockableUsage>(scoped);
+    return std::make_unique<ScopedLockableUsage>(*this);
 }
 
 }

--- a/TactilityHeadless/Include/Tactility/hal/Configuration.h
+++ b/TactilityHeadless/Include/Tactility/hal/Configuration.h
@@ -12,8 +12,8 @@ typedef bool (*InitLvgl)();
 
 class Display;
 class Keyboard;
-typedef Display* (*CreateDisplay)();
-typedef Keyboard* (*CreateKeyboard)();
+typedef std::shared_ptr<Display> (*CreateDisplay)();
+typedef std::shared_ptr<Keyboard> (*CreateKeyboard)();
 typedef std::shared_ptr<Power> (*CreatePower)();
 
 struct Configuration {

--- a/TactilityHeadless/Include/Tactility/hal/Device.h
+++ b/TactilityHeadless/Include/Tactility/hal/Device.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tt::hal {
+
+/**
+ * Base class for HAL-related devices.
+ */
+class Device {
+
+public:
+
+    enum class Type {
+        I2c,
+        Display,
+        Touch,
+        SdCard,
+        Keyboard,
+        Power
+    };
+
+    typedef uint32_t Id;
+
+private:
+
+    Id id;
+
+public:
+
+    Device();
+    virtual ~Device() = default;
+
+    Id getId() const { return id; }
+
+    /** The type of device. */
+    virtual Type getType() const = 0;
+
+    /** The part number or hardware name e.g. TdeckTouch, TdeckDisplay, BQ24295, etc. */
+    virtual std::string getName() const = 0;
+
+    /** A short description of what this device does.
+     * e.g. "USB charging controller with I2C interface."
+     */
+    virtual std::string getDescription() const = 0;
+};
+
+
+/**
+ * Adds a device to the registry.
+ * @warning This will leak memory if you want to destroy a device and don't call unregisterDevice()!
+ */
+void registerDevice(const std::shared_ptr<Device>& device);
+
+/** Remove a device from the registry. */
+void unregisterDevice(const std::shared_ptr<Device>& device);
+
+/** Find a device in the registry by its name. */
+std::shared_ptr<Device> _Nullable findDevice(std::string name);
+
+/** Find a device in the registry by its identifier. */
+std::shared_ptr<Device> _Nullable findDevice(Device::Id id);
+
+/** Find 0, 1 or more devices in the registry by type. */
+std::vector<std::shared_ptr<Device>> findDevices(Device::Type type);
+
+/** Get a copy of the entire device registry in its current state. */
+std::vector<std::shared_ptr<Device>> getDevices();
+
+template<class DeviceType>
+std::shared_ptr<DeviceType> findFirstDevice(Device::Type type) {
+    auto devices = findDevices(type);
+    if (devices.empty()) {
+        return {};
+    } else {
+        auto& first = devices[0];
+        return std::static_pointer_cast<DeviceType>(first);
+    }
+}
+
+}

--- a/TactilityHeadless/Include/Tactility/hal/Device.h
+++ b/TactilityHeadless/Include/Tactility/hal/Device.h
@@ -50,12 +50,12 @@ public:
 
 /**
  * Adds a device to the registry.
- * @warning This will leak memory if you want to destroy a device and don't call unregisterDevice()!
+ * @warning This will leak memory if you want to destroy a device and don't call deregisterDevice()!
  */
 void registerDevice(const std::shared_ptr<Device>& device);
 
 /** Remove a device from the registry. */
-void unregisterDevice(const std::shared_ptr<Device>& device);
+void deregisterDevice(const std::shared_ptr<Device>& device);
 
 /** Find a device in the registry by its name. */
 std::shared_ptr<Device> _Nullable findDevice(std::string name);

--- a/TactilityHeadless/Include/Tactility/hal/Display.h
+++ b/TactilityHeadless/Include/Tactility/hal/Display.h
@@ -1,13 +1,19 @@
 #pragma once
 
-#include "lvgl.h"
+#include "Device.h"
+
+#include <lvgl.h>
 
 namespace tt::hal {
 
 class Touch;
 
-class Display {
+class Display : public Device {
+
 public:
+
+    Type getType() const override { return Type::Display; }
+
     virtual bool start() = 0;
     virtual bool stop() = 0;
 
@@ -15,7 +21,7 @@ public:
     virtual bool isPoweredOn() const { return true; }
     virtual bool supportsPowerControl() const { return false; }
 
-    virtual Touch* _Nullable createTouch() = 0;
+    virtual std::shared_ptr<Touch> _Nullable createTouch() = 0;
 
     /** Set a value in the range [0, 255] */
     virtual void setBacklightDuty(uint8_t backlightDuty) { /* NO-OP */ }

--- a/TactilityHeadless/Include/Tactility/hal/Keyboard.h
+++ b/TactilityHeadless/Include/Tactility/hal/Keyboard.h
@@ -1,13 +1,19 @@
 #pragma once
 
-#include "lvgl.h"
+#include "Device.h"
+
+#include <lvgl.h>
 
 namespace tt::hal {
 
 class Display;
 
-class Keyboard {
+class Keyboard : public Device {
+
 public:
+
+    Type getType() const override { return Type::Keyboard; }
+
     virtual bool start(lv_display_t* display) = 0;
     virtual bool stop() = 0;
     virtual bool isAttached() const = 0;

--- a/TactilityHeadless/Include/Tactility/hal/Power.h
+++ b/TactilityHeadless/Include/Tactility/hal/Power.h
@@ -1,15 +1,18 @@
 #pragma once
 
+#include "Device.h"
 #include <cstdint>
 
 namespace tt::hal {
 
-class Power{
+class Power : public Device {
 
 public:
 
     Power() = default;
-    virtual ~Power() = default;
+    ~Power() override = default;
+
+    Type getType() const override { return Type::Power; }
 
     enum class MetricType {
         IsCharging, // bool

--- a/TactilityHeadless/Include/Tactility/hal/SdCard.h
+++ b/TactilityHeadless/Include/Tactility/hal/SdCard.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Device.h"
+
 #include <Tactility/TactilityCore.h>
 
 namespace tt::hal {
@@ -7,8 +9,10 @@ namespace tt::hal {
 #define TT_SDCARD_MOUNT_NAME "sdcard"
 #define TT_SDCARD_MOUNT_POINT "/sdcard"
 
-class SdCard {
+class SdCard : public Device {
+
 public:
+
     enum class State {
         Mounted,
         Unmounted,
@@ -22,11 +26,15 @@ public:
     };
 
 private:
+
     MountBehaviour mountBehaviour;
 
 public:
+
     explicit SdCard(MountBehaviour mountBehaviour) : mountBehaviour(mountBehaviour) {}
-    virtual ~SdCard() = default;
+    virtual ~SdCard() override = default;
+
+    Type getType() const final { return Type::SdCard; };
 
     virtual bool mount(const char* mountPath) = 0;
     virtual bool unmount() = 0;

--- a/TactilityHeadless/Include/Tactility/hal/SpiSdCard.h
+++ b/TactilityHeadless/Include/Tactility/hal/SpiSdCard.h
@@ -70,6 +70,9 @@ public:
         config(std::move(config))
     {}
 
+    std::string getName() const final { return "SD Card"; }
+    std::string getDescription() const final { return "SD card via SPI interface"; }
+
     bool mount(const char* mountPath) override;
     bool unmount() override;
     State getState() const override;

--- a/TactilityHeadless/Include/Tactility/hal/Touch.h
+++ b/TactilityHeadless/Include/Tactility/hal/Touch.h
@@ -1,14 +1,19 @@
 #pragma once
 
-#include "lvgl.h"
+#include "Device.h"
+
+#include <lvgl.h>
 
 namespace tt::hal {
 
 class Display;
 
-class Touch {
+class Touch : public Device {
 
 public:
+
+    Type getType() const override { return Type::SdCard; }
+
     virtual bool start(lv_display_t* display) = 0;
     virtual bool stop() = 0;
 

--- a/TactilityHeadless/Include/Tactility/hal/i2c/I2cDevice.h
+++ b/TactilityHeadless/Include/Tactility/hal/i2c/I2cDevice.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "./I2c.h"
+#include "I2c.h"
+#include "../Device.h"
+
+namespace tt::hal::i2c {
 
 /**
  * Represents an I2C peripheral at a specific port and address.
@@ -8,7 +11,7 @@
  *
  * All read and write calls are thread-safe.
  */
-class I2cDevice {
+class I2cDevice : public Device {
 
 protected:
 
@@ -16,6 +19,8 @@ protected:
     uint8_t address;
 
     static constexpr TickType_t DEFAULT_TIMEOUT = 1000 / portTICK_PERIOD_MS;
+
+    Type getType() const override { return Type::I2c; }
 
     bool readRegister8(uint8_t reg, uint8_t& result) const;
     bool writeRegister8(uint8_t reg, uint8_t value) const;
@@ -26,7 +31,10 @@ protected:
     bool bitOff(uint8_t reg, uint8_t bitmask) const;
     bool bitOnByIndex(uint8_t reg, uint8_t index) const { return bitOn(reg, 1 << index); }
     bool bitOffByIndex(uint8_t reg, uint8_t index) const { return bitOff(reg, 1 << index); }
+
 public:
 
     explicit I2cDevice(i2c_port_t port, uint32_t address) : port(port), address(address) {}
 };
+
+}

--- a/TactilityHeadless/Source/hal/Device.cpp
+++ b/TactilityHeadless/Source/hal/Device.cpp
@@ -13,10 +13,10 @@ static Device::Id nextId = 0;
 
 Device::Device() : id(nextId++) {}
 
-template <std::ranges::range R>
-auto toVector(R&& r) {
-    auto r_common = r | std::views::common;
-    return std::vector(r_common.begin(), r_common.end());
+template <std::ranges::range RangeType>
+auto toVector(RangeType&& range) {
+    auto view = range | std::views::common;
+    return std::vector(view.begin(), view.end());
 }
 
 void registerDevice(const std::shared_ptr<Device>& device) {

--- a/TactilityHeadless/Source/hal/Device.cpp
+++ b/TactilityHeadless/Source/hal/Device.cpp
@@ -31,7 +31,7 @@ void registerDevice(const std::shared_ptr<Device>& device) {
     }
 }
 
-void unregisterDevice(const std::shared_ptr<Device>& device) {
+void deregisterDevice(const std::shared_ptr<Device>& device) {
     auto scoped_mutex = mutex.scoped();
     auto id_to_remove = device->getId();
     if (scoped_mutex->lock()) {

--- a/TactilityHeadless/Source/hal/Device.cpp
+++ b/TactilityHeadless/Source/hal/Device.cpp
@@ -38,7 +38,12 @@ void deregisterDevice(const std::shared_ptr<Device>& device) {
         auto remove_iterator = std::remove_if(devices.begin(), devices.end(), [id_to_remove](const auto& device) {
             return device->getId() == id_to_remove;
         });
-        devices.erase(remove_iterator);
+        if (remove_iterator != devices.end()) {
+            TT_LOG_I(TAG, "Deregistering %s with id %lu", device->getName().c_str(), device->getId());
+            devices.erase(remove_iterator);
+        } else {
+            TT_LOG_W(TAG, "Deregistering %s with id %lu failed: not found", device->getName().c_str(), device->getId());
+        }
     }
 }
 

--- a/TactilityHeadless/Source/hal/Device.cpp
+++ b/TactilityHeadless/Source/hal/Device.cpp
@@ -1,0 +1,92 @@
+#include "Tactility/hal/Device.h"
+
+#include <ranges>
+#include <Tactility/Mutex.h>
+
+namespace tt::hal {
+
+std::vector<std::shared_ptr<Device>> devices;
+Mutex mutex = Mutex(Mutex::Type::Recursive);
+static Device::Id nextId = 0;
+
+#define TAG "devices"
+
+Device::Device() : id(nextId++) {}
+
+template <std::ranges::range R>
+auto toVector(R&& r) {
+    auto r_common = r | std::views::common;
+    return std::vector(r_common.begin(), r_common.end());
+}
+
+void registerDevice(const std::shared_ptr<Device>& device) {
+    auto scoped_mutex = mutex.scoped();
+    if (scoped_mutex->lock()) {
+        if (findDevice(device->getId()) == nullptr) {
+            devices.push_back(device);
+            TT_LOG_I(TAG, "Registered %s with id %lu", device->getName().c_str(), device->getId());
+        } else {
+            TT_LOG_W(TAG, "Device %s with id %lu was already registered", device->getName().c_str(), device->getId());
+        }
+    }
+}
+
+void unregisterDevice(const std::shared_ptr<Device>& device) {
+    auto scoped_mutex = mutex.scoped();
+    auto id_to_remove = device->getId();
+    if (scoped_mutex->lock()) {
+        auto remove_iterator = std::remove_if(devices.begin(), devices.end(), [id_to_remove](const auto& device) {
+            return device->getId() == id_to_remove;
+        });
+        devices.erase(remove_iterator);
+    }
+}
+
+std::vector<std::shared_ptr<Device>> findDevices(const std::function<bool(const std::shared_ptr<Device>&)>& filterFunction) {
+    auto scoped_mutex = mutex.scoped();
+    if (scoped_mutex->lock()) {
+        auto devices_view = devices | std::views::filter([&filterFunction](auto& device) {
+            return filterFunction(device);
+        });
+        return toVector(devices_view);
+    }
+    return {};
+}
+
+static std::shared_ptr<Device> _Nullable findDevice(const std::function<bool(const std::shared_ptr<Device>&)>& filterFunction) {
+    auto scoped_mutex = mutex.scoped();
+    if (scoped_mutex->lock()) {
+        auto result_set = devices | std::views::filter([&filterFunction](auto& device) {
+             return filterFunction(device);
+        });
+        if (!result_set.empty()) {
+            return result_set.front();
+        }
+    }
+
+    return nullptr;
+}
+
+std::shared_ptr<Device> _Nullable findDevice(std::string name) {
+    return findDevice([&name](auto& device){
+        return device->getName() == name;
+    });
+}
+
+std::shared_ptr<Device> _Nullable findDevice(Device::Id id) {
+    return findDevice([id](auto& device){
+      return device->getId() == id;
+    });
+}
+
+std::vector<std::shared_ptr<Device>> findDevices(Device::Type type) {
+    return findDevices([type](auto& device) {
+        return device->getType() == type;
+    });
+}
+
+std::vector<std::shared_ptr<Device>> getDevices() {
+    return devices;
+}
+
+}

--- a/TactilityHeadless/Source/hal/Hal.cpp
+++ b/TactilityHeadless/Source/hal/Hal.cpp
@@ -1,3 +1,4 @@
+#include "Tactility/hal/Device.h"
 #include "Tactility/hal/Hal_i.h"
 #include "Tactility/hal/i2c/I2c.h"
 
@@ -28,6 +29,12 @@ void init(const Configuration& configuration) {
         if (!configuration.sdcard->mount(TT_SDCARD_MOUNT_POINT)) {
             TT_LOG_W(TAG, "SD card mount failed (init can continue)");
         }
+        hal::registerDevice(configuration.sdcard);
+    }
+
+    if (configuration.power != nullptr) {
+        std::shared_ptr<tt::hal::Power> power = configuration.power();
+        hal::registerDevice(power);
     }
 
     kernel::systemEventPublish(kernel::SystemEvent::BootInitHalEnd);

--- a/TactilityHeadless/Source/hal/i2c/I2cDevice.cpp
+++ b/TactilityHeadless/Source/hal/i2c/I2cDevice.cpp
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+namespace tt::hal::i2c {
+
 bool I2cDevice::readRegister12(uint8_t reg, float& out) const {
     std::uint8_t data[2] = {0};
     if (tt::hal::i2c::masterReadRegister(port, address, reg, data, 2, DEFAULT_TIMEOUT)) {
@@ -59,3 +61,5 @@ bool I2cDevice::bitOff(uint8_t reg, uint8_t bitmask) const {
         return false;
     }
 }
+
+} // namespace

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -4,6 +4,8 @@ set(DOCTESTINC ${PROJECT_SOURCE_DIR}/Include)
 
 enable_testing()
 add_subdirectory(TactilityCore)
+add_subdirectory(TactilityHeadless)
 
 add_custom_target(build-tests)
 add_dependencies(build-tests TactilityCoreTests)
+add_dependencies(build-tests TactilityHeadlessTests)

--- a/Tests/TactilityHeadless/CMakeLists.txt
+++ b/Tests/TactilityHeadless/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(TactilityCoreTests)
+
+enable_language(C CXX ASM)
+
+set(CMAKE_CXX_COMPILER g++)
+
+file(GLOB_RECURSE TEST_SOURCES ${PROJECT_SOURCE_DIR}/*.cpp)
+add_executable(TactilityHeadlessTests EXCLUDE_FROM_ALL ${TEST_SOURCES})
+
+add_definitions(-D_Nullable=)
+add_definitions(-D_Nonnull=)
+
+target_include_directories(TactilityHeadlessTests PRIVATE
+    ${DOCTESTINC}
+)
+
+add_test(NAME TactilityHeadlessTests
+    COMMAND TactilityHeadlessTests
+)
+
+target_link_libraries(TactilityHeadlessTests PRIVATE
+    Tactility
+    TactilityCore
+    TactilityHeadless
+    Simulator
+    SDL2::SDL2-static SDL2-static
+)

--- a/Tests/TactilityHeadless/HalDeviceTest.cpp
+++ b/Tests/TactilityHeadless/HalDeviceTest.cpp
@@ -1,0 +1,98 @@
+#include "doctest.h"
+#include <Tactility/hal/Device.h>
+
+#include <utility>
+
+using namespace tt;
+
+class TestDevice final : public hal::Device {
+
+private:
+
+    hal::Device::Type type;
+    std::string name;
+    std::string description;
+
+public:
+
+    TestDevice(hal::Device::Type type, std::string name, std::string description) :
+        type(type),
+        name(std::move(name)),
+        description(std::move(description))
+    {}
+
+    TestDevice() : TestDevice(hal::Device::Type::Power, "PowerMock", "PowerMock description") {}
+
+    ~TestDevice() final = default;
+
+    Type getType() const final { return type; }
+    std::string getName() const final { return name; }
+    std::string getDescription() const final { return description; }
+};
+
+class DeviceAutoRegistration {
+
+    std::shared_ptr<hal::Device> device;
+
+public:
+
+    explicit DeviceAutoRegistration(std::shared_ptr<hal::Device> inDevice) : device(std::move(inDevice)) {
+        hal::registerDevice(device);
+    }
+
+    ~DeviceAutoRegistration() {
+        hal::deregisterDevice(device);
+    }
+};
+
+/** We add 3 tests into 1 to ensure cleanup happens */
+TEST_CASE("registering and deregistering a device works") {
+    auto device = std::make_shared<TestDevice>();
+
+    // Pre-registration
+    CHECK_EQ(hal::findDevice(device->getId()), nullptr);
+
+    // Registration
+    hal::registerDevice(device);
+    auto found_device = hal::findDevice(device->getId());
+    CHECK_NE(found_device, nullptr);
+    CHECK_EQ(found_device->getId(), device->getId());
+
+    // Deregistration
+    hal::deregisterDevice(device);
+    CHECK_EQ(hal::findDevice(device->getId()), nullptr);
+    found_device = nullptr; // to decrease use count
+    CHECK_EQ(device.use_count(), 1);
+}
+
+TEST_CASE("find device by id") {
+    auto device = std::make_shared<TestDevice>();
+    DeviceAutoRegistration auto_registration(device);
+
+    auto found_device = hal::findDevice(device->getId());
+    CHECK_NE(found_device, nullptr);
+    CHECK_EQ(found_device->getId(), device->getId());
+}
+
+TEST_CASE("find device by name") {
+    auto device = std::make_shared<TestDevice>();
+    DeviceAutoRegistration auto_registration(device);
+
+    auto found_device = hal::findDevice(device->getName());
+    CHECK_NE(found_device, nullptr);
+    CHECK_EQ(found_device->getId(), device->getId());
+}
+
+TEST_CASE("find device by type") {
+    // Headless mode shouldn't have a display, so we want to create one to find only our own display as unique device
+    // We first verify the initial assumption that there is no display:
+    auto unexpected_display = hal::findFirstDevice<TestDevice>(hal::Device::Type::Display);
+    CHECK_EQ(unexpected_display, nullptr);
+
+    auto device = std::make_shared<TestDevice>(hal::Device::Type::Display, "", "");
+    DeviceAutoRegistration auto_registration(device);
+
+    auto found_device = hal::findFirstDevice<TestDevice>(hal::Device::Type::Display);
+    CHECK_NE(found_device, nullptr);
+    CHECK_EQ(found_device->getId(), device->getId());
+}

--- a/Tests/TactilityHeadless/HalDeviceTest.cpp
+++ b/Tests/TactilityHeadless/HalDeviceTest.cpp
@@ -89,7 +89,7 @@ TEST_CASE("find device by type") {
     auto unexpected_display = hal::findFirstDevice<TestDevice>(hal::Device::Type::Display);
     CHECK_EQ(unexpected_display, nullptr);
 
-    auto device = std::make_shared<TestDevice>(hal::Device::Type::Display, "", "");
+    auto device = std::make_shared<TestDevice>(hal::Device::Type::Display, "DisplayMock", "");
     DeviceAutoRegistration auto_registration(device);
 
     auto found_device = hal::findFirstDevice<TestDevice>(hal::Device::Type::Display);

--- a/Tests/TactilityHeadless/Main.cpp
+++ b/Tests/TactilityHeadless/Main.cpp
@@ -1,0 +1,51 @@
+#define DOCTEST_CONFIG_IMPLEMENT
+#include "doctest.h"
+#include <cassert>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+typedef struct {
+    int argc;
+    char** argv;
+    int result;
+} TestTaskData;
+
+void test_task(void* parameter) {
+    auto* data = (TestTaskData*)parameter;
+
+    doctest::Context context;
+
+    context.applyCommandLine(data->argc, data->argv);
+
+    // overrides
+    context.setOption("no-breaks", true); // don't break in the debugger when assertions fail
+
+    data->result = context.run();
+
+    if (context.shouldExit()) { // important - query flags (and --exit) rely on the user doing this
+        vTaskEndScheduler();
+    }
+
+    vTaskDelete(nullptr);
+}
+
+int main(int argc, char** argv) {
+    TestTaskData data = {
+        .argc = argc,
+        .argv = argv,
+        .result = 0
+    };
+
+    BaseType_t task_result = xTaskCreate(
+        test_task,
+        "test_task",
+        8192,
+        &data,
+        1,
+        nullptr
+    );
+    assert(task_result == pdPASS);
+
+    vTaskStartScheduler();
+}


### PR DESCRIPTION
- Added `tt::hal::Device` and functions (de)register devices and search for them.
- Refactored apps: `Power` and `Display` settings apps now use the device API to find devices.
- Implemented the new API for all existing drivers for all devices, including the simulator.
- Updated HAL Configuration to return `std::shared_ptr` instead of raw pointers.
- Added test project for headless tests and implemented tests for the new code.