### PR TITLE
HAL renaming & relocation

### DIFF
--- a/Boards/CYD-2432S024C/Source/hal/YellowDisplay.cpp
+++ b/Boards/CYD-2432S024C/Source/hal/YellowDisplay.cpp
@@ -71,7 +71,7 @@ void setBacklightDuty(uint8_t backlightDuty) {
 }
 
 
-std::shared_ptr<tt::hal::display::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay() {
 
     auto touch = std::make_shared<YellowTouch>();
 

--- a/Boards/CYD-2432S024C/Source/hal/YellowDisplay.cpp
+++ b/Boards/CYD-2432S024C/Source/hal/YellowDisplay.cpp
@@ -71,7 +71,7 @@ void setBacklightDuty(uint8_t backlightDuty) {
 }
 
 
-std::shared_ptr<tt::hal::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::Display> createDisplay() {
 
     auto touch = std::make_shared<YellowTouch>();
 

--- a/Boards/CYD-2432S024C/Source/hal/YellowDisplay.h
+++ b/Boards/CYD-2432S024C/Source/hal/YellowDisplay.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Tactility/hal/display/Display.h>
+#include "Tactility/hal/display/DisplayDevice.h"
 #include <memory>
 
-std::shared_ptr<tt::hal::display::Display> createDisplay();
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay();

--- a/Boards/CYD-2432S024C/Source/hal/YellowDisplay.h
+++ b/Boards/CYD-2432S024C/Source/hal/YellowDisplay.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Tactility/hal/Display.h>
+#include <Tactility/hal/display/Display.h>
 #include <memory>
 
-std::shared_ptr<tt::hal::Display> createDisplay();
+std::shared_ptr<tt::hal::display::Display> createDisplay();

--- a/Boards/CYD-2432S024C/Source/hal/YellowSdCard.cpp
+++ b/Boards/CYD-2432S024C/Source/hal/YellowSdCard.cpp
@@ -2,30 +2,30 @@
 
 #define TAG "twodotfour_sdcard"
 
+#include <Tactility/hal/sdcard/SpiSdCardDevice.h>
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/sdcard/SpiSdCard.h>
 
 #define SDCARD_SPI_HOST SPI3_HOST
 #define SDCARD_PIN_CS GPIO_NUM_5
 
-using tt::hal::sdcard::SpiSdCard;
+using tt::hal::sdcard::SpiSdCardDevice;
 
-std::shared_ptr<SdCard> createYellowSdCard() {
-    auto* configuration = new SpiSdCard::Config(
+std::shared_ptr<SdCardDevice> createYellowSdCard() {
+    auto* configuration = new SpiSdCardDevice::Config(
         SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
-        SdCard::MountBehaviour::AtBoot,
+        SdCardDevice::MountBehaviour::AtBoot,
         std::make_shared<tt::Mutex>(),
         std::vector<gpio_num_t>(),
         SDCARD_SPI_HOST
     );
 
-    auto* sdcard = (SdCard*) new SpiSdCard(
-        std::unique_ptr<SpiSdCard::Config>(configuration)
+    auto* sdcard = (SdCardDevice*) new SpiSdCardDevice(
+        std::unique_ptr<SpiSdCardDevice::Config>(configuration)
     );
 
-    return std::shared_ptr<SdCard>(sdcard);
+    return std::shared_ptr<SdCardDevice>(sdcard);
 }
 

--- a/Boards/CYD-2432S024C/Source/hal/YellowSdCard.cpp
+++ b/Boards/CYD-2432S024C/Source/hal/YellowSdCard.cpp
@@ -3,13 +3,15 @@
 #define TAG "twodotfour_sdcard"
 
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/SpiSdCard.h>
+#include <Tactility/hal/sdcard/SpiSdCard.h>
 
 #define SDCARD_SPI_HOST SPI3_HOST
 #define SDCARD_PIN_CS GPIO_NUM_5
 
+using tt::hal::sdcard::SpiSdCard;
+
 std::shared_ptr<SdCard> createYellowSdCard() {
-    auto* configuration = new tt::hal::SpiSdCard::Config(
+    auto* configuration = new SpiSdCard::Config(
         SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,

--- a/Boards/CYD-2432S024C/Source/hal/YellowSdCard.h
+++ b/Boards/CYD-2432S024C/Source/hal/YellowSdCard.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <Tactility/hal/sdcard/SdCard.h>
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 
-using tt::hal::sdcard::SdCard;
+using tt::hal::sdcard::SdCardDevice;
 
-std::shared_ptr<SdCard> createYellowSdCard();
+std::shared_ptr<SdCardDevice> createYellowSdCard();
 

--- a/Boards/CYD-2432S024C/Source/hal/YellowSdCard.h
+++ b/Boards/CYD-2432S024C/Source/hal/YellowSdCard.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <Tactility/hal/SdCard.h>
+#include <Tactility/hal/sdcard/SdCard.h>
 
-using namespace tt::hal;
+using tt::hal::sdcard::SdCard;
 
 std::shared_ptr<SdCard> createYellowSdCard();
 

--- a/Boards/CYD-2432S024C/Source/hal/YellowTouch.h
+++ b/Boards/CYD-2432S024C/Source/hal/YellowTouch.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Tactility/hal/touch/Touch.h>
+#include "Tactility/hal/touch/TouchDevice.h"
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_touch.h>
 
-class YellowTouch : public tt::hal::touch::Touch {
+class YellowTouch : public tt::hal::touch::TouchDevice {
 
 private:
 

--- a/Boards/CYD-2432S024C/Source/hal/YellowTouch.h
+++ b/Boards/CYD-2432S024C/Source/hal/YellowTouch.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Tactility/hal/Touch.h>
+#include <Tactility/hal/touch/Touch.h>
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_touch.h>
 
-class YellowTouch : public tt::hal::Touch {
+class YellowTouch : public tt::hal::touch::Touch {
 
 private:
 

--- a/Boards/LilygoTdeck/Source/hal/TdeckDisplay.cpp
+++ b/Boards/LilygoTdeck/Source/hal/TdeckDisplay.cpp
@@ -191,7 +191,7 @@ void TdeckDisplay::setPowerOn(bool turnOn) {
     }
 }
 
-std::shared_ptr<tt::hal::touch::Touch> _Nullable TdeckDisplay::createTouch() {
+std::shared_ptr<tt::hal::touch::TouchDevice> _Nullable TdeckDisplay::createTouch() {
     return std::make_shared<TdeckTouch>();
 }
 
@@ -233,6 +233,6 @@ void TdeckDisplay::setGammaCurve(uint8_t index) {
     }
 }
 
-std::shared_ptr<tt::hal::display::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay() {
     return std::make_shared<TdeckDisplay>();
 }

--- a/Boards/LilygoTdeck/Source/hal/TdeckDisplay.cpp
+++ b/Boards/LilygoTdeck/Source/hal/TdeckDisplay.cpp
@@ -191,7 +191,7 @@ void TdeckDisplay::setPowerOn(bool turnOn) {
     }
 }
 
-std::shared_ptr<tt::hal::Touch> _Nullable TdeckDisplay::createTouch() {
+std::shared_ptr<tt::hal::touch::Touch> _Nullable TdeckDisplay::createTouch() {
     return std::make_shared<TdeckTouch>();
 }
 
@@ -233,6 +233,6 @@ void TdeckDisplay::setGammaCurve(uint8_t index) {
     }
 }
 
-std::shared_ptr<tt::hal::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::Display> createDisplay() {
     return std::make_shared<TdeckDisplay>();
 }

--- a/Boards/LilygoTdeck/Source/hal/TdeckDisplay.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckDisplay.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "Tactility/hal/display/DisplayDevice.h"
 #include <esp_lcd_types.h>
 #include <lvgl.h>
-#include <Tactility/hal/display/Display.h>
 
-class TdeckDisplay : public tt::hal::display::Display {
+class TdeckDisplay : public tt::hal::display::DisplayDevice {
 
 private:
 
@@ -26,7 +26,7 @@ public:
     bool isPoweredOn() const override { return poweredOn; };
     bool supportsPowerControl() const override { return true; }
 
-    std::shared_ptr<tt::hal::touch::Touch> _Nullable createTouch() override;
+    std::shared_ptr<tt::hal::touch::TouchDevice> _Nullable createTouch() override;
 
     void setBacklightDuty(uint8_t backlightDuty) override;
     bool supportsBacklightDuty() const override { return true; }
@@ -35,10 +35,6 @@ public:
     uint8_t getGammaCurveCount() const override { return 4; };
 
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
-
-private:
-
-    static bool startBacklight();
 };
 
-std::shared_ptr<tt::hal::display::Display> createDisplay();
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay();

--- a/Boards/LilygoTdeck/Source/hal/TdeckDisplay.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckDisplay.h
@@ -2,9 +2,9 @@
 
 #include <esp_lcd_types.h>
 #include <lvgl.h>
-#include <Tactility/hal/Display.h>
+#include <Tactility/hal/display/Display.h>
 
-class TdeckDisplay : public tt::hal::Display {
+class TdeckDisplay : public tt::hal::display::Display {
 
 private:
 
@@ -26,7 +26,7 @@ public:
     bool isPoweredOn() const override { return poweredOn; };
     bool supportsPowerControl() const override { return true; }
 
-    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() override;
+    std::shared_ptr<tt::hal::touch::Touch> _Nullable createTouch() override;
 
     void setBacklightDuty(uint8_t backlightDuty) override;
     bool supportsBacklightDuty() const override { return true; }
@@ -41,4 +41,4 @@ private:
     static bool startBacklight();
 };
 
-std::shared_ptr<tt::hal::Display> createDisplay();
+std::shared_ptr<tt::hal::display::Display> createDisplay();

--- a/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.cpp
+++ b/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.cpp
@@ -62,6 +62,6 @@ bool TdeckKeyboard::isAttached() const {
     return tt::hal::i2c::masterHasDeviceAtAddress(TDECK_KEYBOARD_I2C_BUS_HANDLE, TDECK_KEYBOARD_SLAVE_ADDRESS, 100);
 }
 
-std::shared_ptr<tt::hal::keyboard::Keyboard> createKeyboard() {
+std::shared_ptr<tt::hal::keyboard::KeyboardDevice> createKeyboard() {
     return std::make_shared<TdeckKeyboard>();
 }

--- a/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.cpp
+++ b/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.cpp
@@ -62,6 +62,6 @@ bool TdeckKeyboard::isAttached() const {
     return tt::hal::i2c::masterHasDeviceAtAddress(TDECK_KEYBOARD_I2C_BUS_HANDLE, TDECK_KEYBOARD_SLAVE_ADDRESS, 100);
 }
 
-std::shared_ptr<tt::hal::Keyboard> createKeyboard() {
+std::shared_ptr<tt::hal::keyboard::Keyboard> createKeyboard() {
     return std::make_shared<TdeckKeyboard>();
 }

--- a/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Tactility/hal/keyboard/Keyboard.h>
+#include <Tactility/hal/keyboard/KeyboardDevice.h>
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_panel_io_interface.h>
 #include <esp_lcd_touch.h>
 
-class TdeckKeyboard : public tt::hal::keyboard::Keyboard {
+class TdeckKeyboard : public tt::hal::keyboard::KeyboardDevice {
 
 private:
 
@@ -22,4 +22,4 @@ public:
     lv_indev_t* _Nullable getLvglIndev() override { return deviceHandle; }
 };
 
-std::shared_ptr<tt::hal::keyboard::Keyboard> createKeyboard();
+std::shared_ptr<tt::hal::keyboard::KeyboardDevice> createKeyboard();

--- a/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckKeyboard.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Tactility/hal/Keyboard.h>
+#include <Tactility/hal/keyboard/Keyboard.h>
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_panel_io_interface.h>
 #include <esp_lcd_touch.h>
 
-class TdeckKeyboard : public tt::hal::Keyboard {
+class TdeckKeyboard : public tt::hal::keyboard::Keyboard {
 
 private:
 
@@ -22,4 +22,4 @@ public:
     lv_indev_t* _Nullable getLvglIndev() override { return deviceHandle; }
 };
 
-std::shared_ptr<tt::hal::Keyboard> createKeyboard();
+std::shared_ptr<tt::hal::keyboard::Keyboard> createKeyboard();

--- a/Boards/LilygoTdeck/Source/hal/TdeckPower.cpp
+++ b/Boards/LilygoTdeck/Source/hal/TdeckPower.cpp
@@ -66,7 +66,7 @@ bool TdeckPower::supportsMetric(MetricType type) const {
     return false; // Safety guard for when new enum values are introduced
 }
 
-bool TdeckPower::getMetric(Power::MetricType type, Power::MetricData& data) {
+bool TdeckPower::getMetric(MetricType type, MetricData& data) {
     switch (type) {
         using enum MetricType;
         case BatteryVoltage:
@@ -119,9 +119,9 @@ bool TdeckPower::readBatteryVoltageSampled(uint32_t& output) {
     }
 }
 
-static std::shared_ptr<Power> power;
+static std::shared_ptr<PowerDevice> power;
 
-std::shared_ptr<Power> tdeck_get_power() {
+std::shared_ptr<PowerDevice> tdeck_get_power() {
     if (power == nullptr) {
         power = std::make_shared<TdeckPower>();
     }

--- a/Boards/LilygoTdeck/Source/hal/TdeckPower.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckPower.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Tactility/hal/Power.h>
+#include <Tactility/hal/power/Power.h>
 #include <esp_adc/adc_oneshot.h>
 #include <memory>
 
-using namespace tt::hal;
+using tt::hal::power::Power;
 
 class TdeckPower : public Power {
 
@@ -18,7 +18,7 @@ public:
     std::string getName() const final { return "ADC Power Measurement"; }
     std::string getDescription() const final { return "Power measurement interface via ADC pin"; }
 
-    bool supportsMetric(MetricType type) const override;
+    bool supportsMetric(Power::MetricType type) const override;
     bool getMetric(Power::MetricType type, Power::MetricData& data) override;
 
 private:

--- a/Boards/LilygoTdeck/Source/hal/TdeckPower.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckPower.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <Tactility/hal/power/Power.h>
+#include "Tactility/hal/power/PowerDevice.h"
 #include <esp_adc/adc_oneshot.h>
 #include <memory>
 
-using tt::hal::power::Power;
+using tt::hal::power::PowerDevice;
 
-class TdeckPower : public Power {
+class TdeckPower : public PowerDevice {
 
     adc_oneshot_unit_handle_t adcHandle = nullptr;
 
@@ -18,8 +18,8 @@ public:
     std::string getName() const final { return "ADC Power Measurement"; }
     std::string getDescription() const final { return "Power measurement interface via ADC pin"; }
 
-    bool supportsMetric(Power::MetricType type) const override;
-    bool getMetric(Power::MetricType type, Power::MetricData& data) override;
+    bool supportsMetric(MetricType type) const override;
+    bool getMetric(MetricType type, MetricData& data) override;
 
 private:
 
@@ -27,4 +27,4 @@ private:
     bool readBatteryVoltageOnce(uint32_t& output);
 };
 
-std::shared_ptr<Power> tdeck_get_power();
+std::shared_ptr<PowerDevice> tdeck_get_power();

--- a/Boards/LilygoTdeck/Source/hal/TdeckSdCard.cpp
+++ b/Boards/LilygoTdeck/Source/hal/TdeckSdCard.cpp
@@ -1,16 +1,18 @@
 #include "TdeckSdCard.h"
 
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/SpiSdCard.h>
+#include <Tactility/hal/sdcard/SpiSdCard.h>
 
 #include <esp_vfs_fat.h>
+
+using tt::hal::sdcard::SpiSdCard;
 
 #define TDECK_SDCARD_PIN_CS GPIO_NUM_39
 #define TDECK_LCD_PIN_CS GPIO_NUM_12
 #define TDECK_RADIO_PIN_CS GPIO_NUM_9
 
 std::shared_ptr<SdCard> createTdeckSdCard() {
-    auto* configuration = new tt::hal::SpiSdCard::Config(
+    auto* configuration = new SpiSdCard::Config(
         TDECK_SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,

--- a/Boards/LilygoTdeck/Source/hal/TdeckSdCard.cpp
+++ b/Boards/LilygoTdeck/Source/hal/TdeckSdCard.cpp
@@ -1,23 +1,23 @@
 #include "TdeckSdCard.h"
 
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/sdcard/SpiSdCard.h>
+#include <Tactility/hal/sdcard/SpiSdCardDevice.h>
 
 #include <esp_vfs_fat.h>
 
-using tt::hal::sdcard::SpiSdCard;
+using tt::hal::sdcard::SpiSdCardDevice;
 
 #define TDECK_SDCARD_PIN_CS GPIO_NUM_39
 #define TDECK_LCD_PIN_CS GPIO_NUM_12
 #define TDECK_RADIO_PIN_CS GPIO_NUM_9
 
-std::shared_ptr<SdCard> createTdeckSdCard() {
-    auto* configuration = new SpiSdCard::Config(
+std::shared_ptr<SdCardDevice> createTdeckSdCard() {
+    auto* configuration = new SpiSdCardDevice::Config(
         TDECK_SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
-        SdCard::MountBehaviour::AtBoot,
+        SdCardDevice::MountBehaviour::AtBoot,
         tt::lvgl::getLvglSyncLockable(),
         {
             TDECK_RADIO_PIN_CS,
@@ -25,9 +25,9 @@ std::shared_ptr<SdCard> createTdeckSdCard() {
         }
     );
 
-    auto* sdcard = (SdCard*) new SpiSdCard(
-        std::unique_ptr<SpiSdCard::Config>(configuration)
+    auto* sdcard = (SdCardDevice*) new SpiSdCardDevice(
+        std::unique_ptr<SpiSdCardDevice::Config>(configuration)
     );
 
-    return std::shared_ptr<SdCard>(sdcard);
+    return std::shared_ptr<SdCardDevice>(sdcard);
 }

--- a/Boards/LilygoTdeck/Source/hal/TdeckSdCard.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckSdCard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Tactility/hal/SdCard.h>
+#include <Tactility/hal/sdcard/SdCard.h>
 
-using namespace tt::hal;
+using tt::hal::sdcard::SdCard;
 
 std::shared_ptr<SdCard> createTdeckSdCard();

--- a/Boards/LilygoTdeck/Source/hal/TdeckSdCard.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckSdCard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Tactility/hal/sdcard/SdCard.h>
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 
-using tt::hal::sdcard::SdCard;
+using tt::hal::sdcard::SdCardDevice;
 
-std::shared_ptr<SdCard> createTdeckSdCard();
+std::shared_ptr<SdCardDevice> createTdeckSdCard();

--- a/Boards/LilygoTdeck/Source/hal/TdeckTouch.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckTouch.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Tactility/hal/touch/Touch.h>
+#include "Tactility/hal/touch/TouchDevice.h"
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_panel_io_interface.h>
 #include <esp_lcd_touch.h>
 
-class TdeckTouch : public tt::hal::touch::Touch {
+class TdeckTouch : public tt::hal::touch::TouchDevice {
 
 private:
 

--- a/Boards/LilygoTdeck/Source/hal/TdeckTouch.h
+++ b/Boards/LilygoTdeck/Source/hal/TdeckTouch.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Tactility/hal/Touch.h>
+#include <Tactility/hal/touch/Touch.h>
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_panel_io_interface.h>
 #include <esp_lcd_touch.h>
 
-class TdeckTouch : public tt::hal::Touch {
+class TdeckTouch : public tt::hal::touch::Touch {
 
 private:
 

--- a/Boards/M5stackCore2/Source/hal/Core2Display.cpp
+++ b/Boards/M5stackCore2/Source/hal/Core2Display.cpp
@@ -3,7 +3,7 @@
 
 #include <Ili934xDisplay.h>
 
-std::shared_ptr<tt::hal::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::Display> createDisplay() {
     auto touch = std::make_shared<Core2Touch>();
 
     auto configuration = std::make_unique<Ili934xDisplay::Configuration>(

--- a/Boards/M5stackCore2/Source/hal/Core2Display.cpp
+++ b/Boards/M5stackCore2/Source/hal/Core2Display.cpp
@@ -3,7 +3,7 @@
 
 #include <Ili934xDisplay.h>
 
-std::shared_ptr<tt::hal::display::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay() {
     auto touch = std::make_shared<Core2Touch>();
 
     auto configuration = std::make_unique<Ili934xDisplay::Configuration>(

--- a/Boards/M5stackCore2/Source/hal/Core2Display.h
+++ b/Boards/M5stackCore2/Source/hal/Core2Display.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Tactility/hal/Display.h>
+#include <Tactility/hal/display/Display.h>
 #include <memory>
 
 #define CORE2_LCD_SPI_HOST SPI2_HOST
@@ -11,4 +11,4 @@
 #define CORE2_LCD_DRAW_BUFFER_HEIGHT (CORE2_LCD_VERTICAL_RESOLUTION / 10)
 #define CORE2_LCD_DRAW_BUFFER_SIZE (CORE2_LCD_HORIZONTAL_RESOLUTION * CORE2_LCD_DRAW_BUFFER_HEIGHT)
 
-std::shared_ptr<tt::hal::Display> createDisplay();
+std::shared_ptr<tt::hal::display::Display> createDisplay();

--- a/Boards/M5stackCore2/Source/hal/Core2Display.h
+++ b/Boards/M5stackCore2/Source/hal/Core2Display.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Tactility/hal/display/Display.h>
+#include "Tactility/hal/display/DisplayDevice.h"
 #include <memory>
 
 #define CORE2_LCD_SPI_HOST SPI2_HOST
@@ -11,4 +11,4 @@
 #define CORE2_LCD_DRAW_BUFFER_HEIGHT (CORE2_LCD_VERTICAL_RESOLUTION / 10)
 #define CORE2_LCD_DRAW_BUFFER_SIZE (CORE2_LCD_HORIZONTAL_RESOLUTION * CORE2_LCD_DRAW_BUFFER_HEIGHT)
 
-std::shared_ptr<tt::hal::display::Display> createDisplay();
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay();

--- a/Boards/M5stackCore2/Source/hal/Core2Power.cpp
+++ b/Boards/M5stackCore2/Source/hal/Core2Power.cpp
@@ -20,7 +20,7 @@ bool Core2Power::supportsMetric(MetricType type) const {
     return false; // Safety guard for when new enum values are introduced
 }
 
-bool Core2Power::getMetric(Power::MetricType type, Power::MetricData& data) {
+bool Core2Power::getMetric(MetricType type, MetricData& data) {
     switch (type) {
         using enum MetricType;
         case BatteryVoltage: {
@@ -100,9 +100,9 @@ void Core2Power::setAllowedToCharge(bool canCharge) {
     }
 }
 
-static std::shared_ptr<Power> power;
+static std::shared_ptr<PowerDevice> power;
 
-std::shared_ptr<Power> createPower() {
+std::shared_ptr<PowerDevice> createPower() {
     if (power == nullptr) {
         power = std::make_shared<Core2Power>();
     }

--- a/Boards/M5stackCore2/Source/hal/Core2Power.h
+++ b/Boards/M5stackCore2/Source/hal/Core2Power.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Tactility/hal/power/Power.h>
+#include "Tactility/hal/power/PowerDevice.h"
 #include <memory>
 
-using tt::hal::power::Power;
+using tt::hal::power::PowerDevice;
 
-class Core2Power : public Power {
+class Core2Power : public PowerDevice {
 
 public:
 
@@ -16,11 +16,11 @@ public:
     std::string getDescription() const final { return "Power management via I2C"; }
 
     bool supportsMetric(MetricType type) const override;
-    bool getMetric(Power::MetricType type, Power::MetricData& data) override;
+    bool getMetric(MetricType type, MetricData& data) override;
 
     bool supportsChargeControl() const override { return true; }
     bool isAllowedToCharge() const override;
     void setAllowedToCharge(bool canCharge) override;
 };
 
-std::shared_ptr<Power> createPower();
+std::shared_ptr<PowerDevice> createPower();

--- a/Boards/M5stackCore2/Source/hal/Core2Power.h
+++ b/Boards/M5stackCore2/Source/hal/Core2Power.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <Tactility/hal/Power.h>
+#include <Tactility/hal/power/Power.h>
 #include <memory>
 
-using namespace tt::hal;
+using tt::hal::power::Power;
 
 class Core2Power : public Power {
 

--- a/Boards/M5stackCore2/Source/hal/Core2SdCard.cpp
+++ b/Boards/M5stackCore2/Source/hal/Core2SdCard.cpp
@@ -1,15 +1,17 @@
 #include "Core2SdCard.h"
 
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/SpiSdCard.h>
+#include <Tactility/hal/sdcard/SpiSdCard.h>
 
 #include <esp_vfs_fat.h>
 
 #define CORE2_SDCARD_PIN_CS GPIO_NUM_4
 #define CORE2_LCD_PIN_CS GPIO_NUM_5
 
+using tt::hal::sdcard::SpiSdCard;
+
 std::shared_ptr<SdCard> createSdCard() {
-    auto* configuration = new tt::hal::SpiSdCard::Config(
+    auto* configuration = new SpiSdCard::Config(
         CORE2_SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,

--- a/Boards/M5stackCore2/Source/hal/Core2SdCard.cpp
+++ b/Boards/M5stackCore2/Source/hal/Core2SdCard.cpp
@@ -1,31 +1,31 @@
 #include "Core2SdCard.h"
 
+#include <Tactility/hal/sdcard/SpiSdCardDevice.h>
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/sdcard/SpiSdCard.h>
 
 #include <esp_vfs_fat.h>
 
 #define CORE2_SDCARD_PIN_CS GPIO_NUM_4
 #define CORE2_LCD_PIN_CS GPIO_NUM_5
 
-using tt::hal::sdcard::SpiSdCard;
+using tt::hal::sdcard::SpiSdCardDevice;
 
-std::shared_ptr<SdCard> createSdCard() {
-    auto* configuration = new SpiSdCard::Config(
+std::shared_ptr<SdCardDevice> createSdCard() {
+    auto* configuration = new SpiSdCardDevice::Config(
         CORE2_SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
-        SdCard::MountBehaviour::AtBoot,
+        SdCardDevice::MountBehaviour::AtBoot,
         tt::lvgl::getLvglSyncLockable(),
         {
             CORE2_LCD_PIN_CS
         }
     );
 
-    auto* sdcard = (SdCard*) new SpiSdCard(
-        std::unique_ptr<SpiSdCard::Config>(configuration)
+    auto* sdcard = (SdCardDevice*) new SpiSdCardDevice(
+        std::unique_ptr<SpiSdCardDevice::Config>(configuration)
     );
 
-    return std::shared_ptr<SdCard>(sdcard);
+    return std::shared_ptr<SdCardDevice>(sdcard);
 }

--- a/Boards/M5stackCore2/Source/hal/Core2SdCard.h
+++ b/Boards/M5stackCore2/Source/hal/Core2SdCard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Tactility/hal/sdcard/SdCard.h>
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 
-using tt::hal::sdcard::SdCard;
+using tt::hal::sdcard::SdCardDevice;
 
-std::shared_ptr<SdCard> createSdCard();
+std::shared_ptr<SdCardDevice> createSdCard();

--- a/Boards/M5stackCore2/Source/hal/Core2SdCard.h
+++ b/Boards/M5stackCore2/Source/hal/Core2SdCard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Tactility/hal/SdCard.h>
+#include <Tactility/hal/sdcard/SdCard.h>
 
-using namespace tt::hal;
+using tt::hal::sdcard::SdCard;
 
 std::shared_ptr<SdCard> createSdCard();

--- a/Boards/M5stackCore2/Source/hal/Core2Touch.h
+++ b/Boards/M5stackCore2/Source/hal/Core2Touch.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Tactility/hal/Touch.h>
+#include <Tactility/hal/touch/Touch.h>
 #include <Tactility/TactilityCore.h>
 #include "ft6x36/FT6X36.h"
 
-class Core2Touch : public tt::hal::Touch {
+class Core2Touch : public tt::hal::touch::Touch {
 
 private:
 

--- a/Boards/M5stackCore2/Source/hal/Core2Touch.h
+++ b/Boards/M5stackCore2/Source/hal/Core2Touch.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Tactility/hal/touch/Touch.h>
-#include <Tactility/TactilityCore.h>
+#include "Tactility/hal/touch/TouchDevice.h"
 #include "ft6x36/FT6X36.h"
+#include <Tactility/TactilityCore.h>
 
-class Core2Touch : public tt::hal::touch::Touch {
+class Core2Touch : public tt::hal::touch::TouchDevice {
 
 private:
 

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Display.cpp
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Display.cpp
@@ -10,7 +10,7 @@
 
 #define TAG "cores3"
 
-void setBacklightDuty(uint8_t backlightDuty) {
+static void setBacklightDuty(uint8_t backlightDuty) {
     const uint8_t voltage = 20 + ((8 * backlightDuty) / 255); // [0b00000, 0b11100] - under 20 is too dark
     // TODO: Refactor to use Axp2102 class with https://github.com/m5stack/M5Unified/blob/b8cfec7fed046242da7f7b8024a4e92004a51ff7/src/utility/AXP2101_Class.cpp#L42
     if (!tt::hal::i2c::masterWriteRegister(I2C_NUM_0, AXP2101_ADDRESS, 0x99, &voltage, 1, 1000)) { // Sets DLD01
@@ -18,7 +18,7 @@ void setBacklightDuty(uint8_t backlightDuty) {
     }
 }
 
-std::shared_ptr<tt::hal::display::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay() {
     auto touch = std::make_shared<CoreS3Touch>();
 
     auto configuration = std::make_unique<Ili934xDisplay::Configuration>(

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Display.cpp
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Display.cpp
@@ -18,7 +18,7 @@ void setBacklightDuty(uint8_t backlightDuty) {
     }
 }
 
-std::shared_ptr<tt::hal::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::Display> createDisplay() {
     auto touch = std::make_shared<CoreS3Touch>();
 
     auto configuration = std::make_unique<Ili934xDisplay::Configuration>(

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Display.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Display.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <Tactility/hal/Display.h>
+#include <Tactility/hal/display/Display.h>
 
-std::shared_ptr<tt::hal::Display> createDisplay();
+std::shared_ptr<tt::hal::display::Display> createDisplay();

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Display.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Display.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <Tactility/hal/display/Display.h>
+#include "Tactility/hal/display/DisplayDevice.h"
 
-std::shared_ptr<tt::hal::display::Display> createDisplay();
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay();

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Power.cpp
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Power.cpp
@@ -14,7 +14,7 @@ bool CoreS3Power::supportsMetric(MetricType type) const {
     return false; // Safety guard for when new enum values are introduced
 }
 
-bool CoreS3Power::getMetric(Power::MetricType type, Power::MetricData& data) {
+bool CoreS3Power::getMetric(MetricType type, MetricData& data) {
     switch (type) {
         using enum MetricType;
         case BatteryVoltage: {
@@ -70,10 +70,10 @@ void CoreS3Power::setAllowedToCharge(bool canCharge) {
     axpDevice->setChargingEnabled(canCharge);
 }
 
-static std::shared_ptr<Power> power;
+static std::shared_ptr<PowerDevice> power;
 extern std::shared_ptr<Axp2101> axp2101;
 
-std::shared_ptr<Power> createPower() {
+std::shared_ptr<PowerDevice> createPower() {
     if (power == nullptr) {
         power = std::make_shared<CoreS3Power>(axp2101);
     }

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Power.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Power.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <Axp2101.h>
-#include <Tactility/hal/Power.h>
+#include <Tactility/hal/power/Power.h>
 #include <memory>
 #include <utility>
 
-using namespace tt::hal;
+using tt::hal::power::Power;
 
 class CoreS3Power final : public Power {
 

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Power.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Power.h
@@ -1,13 +1,13 @@
 #pragma once
 
+#include "Tactility/hal/power/PowerDevice.h"
 #include <Axp2101.h>
-#include <Tactility/hal/power/Power.h>
 #include <memory>
 #include <utility>
 
-using tt::hal::power::Power;
+using tt::hal::power::PowerDevice;
 
-class CoreS3Power final : public Power {
+class CoreS3Power final : public PowerDevice {
 
     std::shared_ptr<Axp2101> axpDevice;
 
@@ -20,11 +20,11 @@ public:
     std::string getDescription() const final { return "Power management via I2C"; }
 
     bool supportsMetric(MetricType type) const override;
-    bool getMetric(Power::MetricType type, Power::MetricData& data) override;
+    bool getMetric(MetricType type, MetricData& data) override;
 
     bool supportsChargeControl() const override { return true; }
     bool isAllowedToCharge() const override;
     void setAllowedToCharge(bool canCharge) override;
 };
 
-std::shared_ptr<Power> createPower();
+std::shared_ptr<PowerDevice> createPower();

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3SdCard.cpp
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3SdCard.cpp
@@ -1,15 +1,17 @@
 #include "CoreS3SdCard.h"
 
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/SpiSdCard.h>
+#include <Tactility/hal/sdcard/SpiSdCard.h>
 
 #include <esp_vfs_fat.h>
 
 #define CORES3_SDCARD_PIN_CS GPIO_NUM_4
 #define CORES3_LCD_PIN_CS GPIO_NUM_3
 
+using tt::hal::sdcard::SpiSdCard;
+
 std::shared_ptr<SdCard> createSdCard() {
-    auto* configuration = new tt::hal::SpiSdCard::Config(
+    auto* configuration = new SpiSdCard::Config(
         CORES3_SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3SdCard.cpp
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3SdCard.cpp
@@ -1,22 +1,22 @@
 #include "CoreS3SdCard.h"
 
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/sdcard/SpiSdCard.h>
+#include <Tactility/hal/sdcard/SpiSdCardDevice.h>
 
 #include <esp_vfs_fat.h>
 
 #define CORES3_SDCARD_PIN_CS GPIO_NUM_4
 #define CORES3_LCD_PIN_CS GPIO_NUM_3
 
-using tt::hal::sdcard::SpiSdCard;
+using tt::hal::sdcard::SpiSdCardDevice;
 
-std::shared_ptr<SdCard> createSdCard() {
-    auto* configuration = new SpiSdCard::Config(
+std::shared_ptr<SdCardDevice> createSdCard() {
+    auto* configuration = new SpiSdCardDevice::Config(
         CORES3_SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
-        SdCard::MountBehaviour::AtBoot,
+        SdCardDevice::MountBehaviour::AtBoot,
         tt::lvgl::getLvglSyncLockable(),
         {
             CORES3_LCD_PIN_CS
@@ -24,9 +24,9 @@ std::shared_ptr<SdCard> createSdCard() {
         SPI3_HOST
     );
 
-    auto* sdcard = (SdCard*) new SpiSdCard(
-        std::unique_ptr<SpiSdCard::Config>(configuration)
+    auto* sdcard = (SdCardDevice*) new SpiSdCardDevice(
+        std::unique_ptr<SpiSdCardDevice::Config>(configuration)
     );
 
-    return std::shared_ptr<SdCard>(sdcard);
+    return std::shared_ptr<SdCardDevice>(sdcard);
 }

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3SdCard.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3SdCard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Tactility/hal/sdcard/SdCard.h>
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 
-using tt::hal::sdcard::SdCard;
+using tt::hal::sdcard::SdCardDevice;
 
-std::shared_ptr<SdCard> createSdCard();
+std::shared_ptr<SdCardDevice> createSdCard();

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3SdCard.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3SdCard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Tactility/hal/SdCard.h>
+#include <Tactility/hal/sdcard/SdCard.h>
 
-using namespace tt::hal;
+using tt::hal::sdcard::SdCard;
 
 std::shared_ptr<SdCard> createSdCard();

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Touch.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Touch.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Tactility/hal/touch/Touch.h>
+#include "Tactility/hal/touch/TouchDevice.h"
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_touch.h>
 
-class CoreS3Touch : public tt::hal::touch::Touch {
+class CoreS3Touch : public tt::hal::touch::TouchDevice {
 
 private:
 

--- a/Boards/M5stackCoreS3/Source/hal/CoreS3Touch.h
+++ b/Boards/M5stackCoreS3/Source/hal/CoreS3Touch.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Tactility/hal/Touch.h>
+#include <Tactility/hal/touch/Touch.h>
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_touch.h>
 
-class CoreS3Touch : public tt::hal::Touch {
+class CoreS3Touch : public tt::hal::touch::Touch {
 
 private:
 

--- a/Boards/Simulator/Source/hal/SdlDisplay.h
+++ b/Boards/Simulator/Source/hal/SdlDisplay.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "SdlTouch.h"
-#include <Tactility/hal/display/Display.h>
+#include "Tactility/hal/display/DisplayDevice.h"
 #include <memory>
 
 /** Hack: variable comes from LvglTask.cpp */
 extern lv_disp_t* displayHandle;
 
-class SdlDisplay final : public tt::hal::display::Display {
+class SdlDisplay final : public tt::hal::display::DisplayDevice {
 
 public:
 
@@ -20,12 +20,12 @@ public:
 
     bool stop() override { tt_crash("Not supported"); }
 
-    std::shared_ptr<tt::hal::touch::Touch> _Nullable createTouch() override { return std::make_shared<SdlTouch>(); }
+    std::shared_ptr<tt::hal::touch::TouchDevice> _Nullable createTouch() override { return std::make_shared<SdlTouch>(); }
 
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
 };
 
-std::shared_ptr<tt::hal::display::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay() {
     return std::make_shared<SdlDisplay>();
 }
 

--- a/Boards/Simulator/Source/hal/SdlDisplay.h
+++ b/Boards/Simulator/Source/hal/SdlDisplay.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "SdlTouch.h"
-#include <Tactility/hal/Display.h>
+#include <Tactility/hal/display/Display.h>
 #include <memory>
 
 /** Hack: variable comes from LvglTask.cpp */
 extern lv_disp_t* displayHandle;
 
-class SdlDisplay final : public tt::hal::Display {
+class SdlDisplay final : public tt::hal::display::Display {
 
 public:
 
@@ -20,12 +20,12 @@ public:
 
     bool stop() override { tt_crash("Not supported"); }
 
-    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() override { return std::make_shared<SdlTouch>(); }
+    std::shared_ptr<tt::hal::touch::Touch> _Nullable createTouch() override { return std::make_shared<SdlTouch>(); }
 
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
 };
 
-std::shared_ptr<tt::hal::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::Display> createDisplay() {
     return std::make_shared<SdlDisplay>();
 }
 

--- a/Boards/Simulator/Source/hal/SdlKeyboard.h
+++ b/Boards/Simulator/Source/hal/SdlKeyboard.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <Tactility/hal/keyboard/Keyboard.h>
+#include <Tactility/hal/keyboard/KeyboardDevice.h>
 #include <Tactility/TactilityCore.h>
 
-class SdlKeyboard final : public tt::hal::keyboard::Keyboard {
+class SdlKeyboard final : public tt::hal::keyboard::KeyboardDevice {
 private:
     lv_indev_t* _Nullable handle = nullptr;
 
@@ -24,6 +24,6 @@ public:
     lv_indev_t* _Nullable getLvglIndev() override { return handle; }
 };
 
-std::shared_ptr<tt::hal::keyboard::Keyboard> createKeyboard() {
+std::shared_ptr<tt::hal::keyboard::KeyboardDevice> createKeyboard() {
     return std::make_shared<SdlKeyboard>();
 }

--- a/Boards/Simulator/Source/hal/SdlKeyboard.h
+++ b/Boards/Simulator/Source/hal/SdlKeyboard.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <Tactility/hal/Keyboard.h>
+#include <Tactility/hal/keyboard/Keyboard.h>
 #include <Tactility/TactilityCore.h>
 
-class SdlKeyboard final : public tt::hal::Keyboard {
+class SdlKeyboard final : public tt::hal::keyboard::Keyboard {
 private:
     lv_indev_t* _Nullable handle = nullptr;
 
@@ -24,6 +24,6 @@ public:
     lv_indev_t* _Nullable getLvglIndev() override { return handle; }
 };
 
-std::shared_ptr<tt::hal::Keyboard> createKeyboard() {
+std::shared_ptr<tt::hal::keyboard::Keyboard> createKeyboard() {
     return std::make_shared<SdlKeyboard>();
 }

--- a/Boards/Simulator/Source/hal/SdlTouch.h
+++ b/Boards/Simulator/Source/hal/SdlTouch.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <Tactility/hal/Touch.h>
+#include <Tactility/hal/touch/Touch.h>
 #include <Tactility/TactilityCore.h>
 
-class SdlTouch final : public tt::hal::Touch {
+class SdlTouch final : public tt::hal::touch::Touch {
 private:
     lv_indev_t* _Nullable handle = nullptr;
 

--- a/Boards/Simulator/Source/hal/SdlTouch.h
+++ b/Boards/Simulator/Source/hal/SdlTouch.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <Tactility/hal/touch/Touch.h>
+#include "Tactility/hal/touch/TouchDevice.h"
 #include <Tactility/TactilityCore.h>
 
-class SdlTouch final : public tt::hal::touch::Touch {
+class SdlTouch final : public tt::hal::touch::TouchDevice {
 private:
     lv_indev_t* _Nullable handle = nullptr;
 

--- a/Boards/Simulator/Source/hal/SimulatorPower.cpp
+++ b/Boards/Simulator/Source/hal/SimulatorPower.cpp
@@ -15,7 +15,7 @@ bool SimulatorPower::supportsMetric(MetricType type) const {
     return false; // Safety guard for when new enum values are introduced
 }
 
-bool SimulatorPower::getMetric(Power::MetricType type, Power::MetricData& data) {
+bool SimulatorPower::getMetric(MetricType type, MetricData& data) {
     switch (type) {
         using enum MetricType;
         case IsCharging:
@@ -35,9 +35,9 @@ bool SimulatorPower::getMetric(Power::MetricType type, Power::MetricData& data) 
     return false; // Safety guard for when new enum values are introduced
 }
 
-static std::shared_ptr<Power> power;
+static std::shared_ptr<PowerDevice> power;
 
-std::shared_ptr<Power> simulatorPower() {
+std::shared_ptr<PowerDevice> simulatorPower() {
     if (power == nullptr) {
         power = std::make_shared<SimulatorPower>();
     }

--- a/Boards/Simulator/Source/hal/SimulatorPower.h
+++ b/Boards/Simulator/Source/hal/SimulatorPower.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <Tactility/hal/Power.h>
+#include <Tactility/hal/power/Power.h>
 #include <memory>
 
-using namespace tt::hal;
+using tt::hal::power::Power;
 
 class SimulatorPower final : public Power {
 

--- a/Boards/Simulator/Source/hal/SimulatorPower.h
+++ b/Boards/Simulator/Source/hal/SimulatorPower.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Tactility/hal/power/Power.h>
+#include "Tactility/hal/power/PowerDevice.h"
 #include <memory>
 
-using tt::hal::power::Power;
+using tt::hal::power::PowerDevice;
 
-class SimulatorPower final : public Power {
+class SimulatorPower final : public PowerDevice {
 
     bool allowedToCharge = false;
 
@@ -18,11 +18,11 @@ public:
     std::string getDescription() const final { return ""; }
 
     bool supportsMetric(MetricType type) const override;
-    bool getMetric(Power::MetricType type, Power::MetricData& data) override;
+    bool getMetric(MetricType type, MetricData& data) override;
 
     bool supportsChargeControl() const override { return true; }
     bool isAllowedToCharge() const override { return allowedToCharge; }
     void setAllowedToCharge(bool canCharge) override { allowedToCharge = canCharge; }
 };
 
-std::shared_ptr<Power> simulatorPower();
+std::shared_ptr<PowerDevice> simulatorPower();

--- a/Boards/Simulator/Source/hal/SimulatorSdCard.h
+++ b/Boards/Simulator/Source/hal/SimulatorSdCard.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <Tactility/hal/sdcard/SdCard.h>
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 #include <Tactility/Mutex.h>
 #include <memory>
 
-using tt::hal::sdcard::SdCard;
+using tt::hal::sdcard::SdCardDevice;
 
-class SimulatorSdCard final : public SdCard {
+class SimulatorSdCard final : public SdCardDevice {
 
 private:
 
@@ -16,7 +16,7 @@ private:
 
 public:
 
-    SimulatorSdCard() : SdCard(MountBehaviour::AtBoot),
+    SimulatorSdCard() : SdCardDevice(MountBehaviour::AtBoot),
         state(State::Unmounted),
         lockable(std::make_shared<tt::Mutex>())
     {}

--- a/Boards/Simulator/Source/hal/SimulatorSdCard.h
+++ b/Boards/Simulator/Source/hal/SimulatorSdCard.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Tactility/hal/SdCard.h>
+#include <Tactility/hal/sdcard/SdCard.h>
 #include <Tactility/Mutex.h>
 #include <memory>
 
-using namespace tt::hal;
+using tt::hal::sdcard::SdCard;
 
 class SimulatorSdCard final : public SdCard {
 

--- a/Boards/UnPhone/Source/hal/UnPhoneDisplay.cpp
+++ b/Boards/UnPhone/Source/hal/UnPhoneDisplay.cpp
@@ -63,10 +63,10 @@ bool UnPhoneDisplay::stop() {
     return true;
 }
 
-std::shared_ptr<tt::hal::Touch> _Nullable UnPhoneDisplay::createTouch() {
+std::shared_ptr<tt::hal::touch::Touch> _Nullable UnPhoneDisplay::createTouch() {
     return std::make_shared<UnPhoneTouch>();
 }
 
-std::shared_ptr<tt::hal::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::Display> createDisplay() {
     return std::make_shared<UnPhoneDisplay>();
 }

--- a/Boards/UnPhone/Source/hal/UnPhoneDisplay.cpp
+++ b/Boards/UnPhone/Source/hal/UnPhoneDisplay.cpp
@@ -63,10 +63,10 @@ bool UnPhoneDisplay::stop() {
     return true;
 }
 
-std::shared_ptr<tt::hal::touch::Touch> _Nullable UnPhoneDisplay::createTouch() {
+std::shared_ptr<tt::hal::touch::TouchDevice> _Nullable UnPhoneDisplay::createTouch() {
     return std::make_shared<UnPhoneTouch>();
 }
 
-std::shared_ptr<tt::hal::display::Display> createDisplay() {
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay() {
     return std::make_shared<UnPhoneDisplay>();
 }

--- a/Boards/UnPhone/Source/hal/UnPhoneDisplay.h
+++ b/Boards/UnPhone/Source/hal/UnPhoneDisplay.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "Tactility/hal/display/DisplayDevice.h"
 #include <esp_lcd_types.h>
 #include <lvgl.h>
-#include <Tactility/hal/display/Display.h>
 
-class UnPhoneDisplay : public tt::hal::display::Display {
+class UnPhoneDisplay : public tt::hal::display::DisplayDevice {
 
 private:
 
@@ -20,9 +20,9 @@ public:
 
     bool stop() override;
 
-    std::shared_ptr<tt::hal::touch::Touch> _Nullable createTouch() override;
+    std::shared_ptr<tt::hal::touch::TouchDevice> _Nullable createTouch() override;
 
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
 };
 
-std::shared_ptr<tt::hal::display::Display> createDisplay();
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay();

--- a/Boards/UnPhone/Source/hal/UnPhoneDisplay.h
+++ b/Boards/UnPhone/Source/hal/UnPhoneDisplay.h
@@ -2,9 +2,9 @@
 
 #include <esp_lcd_types.h>
 #include <lvgl.h>
-#include <Tactility/hal/Display.h>
+#include <Tactility/hal/display/Display.h>
 
-class UnPhoneDisplay : public tt::hal::Display {
+class UnPhoneDisplay : public tt::hal::display::Display {
 
 private:
 
@@ -20,9 +20,9 @@ public:
 
     bool stop() override;
 
-    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() override;
+    std::shared_ptr<tt::hal::touch::Touch> _Nullable createTouch() override;
 
     lv_display_t* _Nullable getLvglDisplay() const override { return displayHandle; }
 };
 
-std::shared_ptr<tt::hal::Display> createDisplay();
+std::shared_ptr<tt::hal::display::Display> createDisplay();

--- a/Boards/UnPhone/Source/hal/UnPhonePower.cpp
+++ b/Boards/UnPhone/Source/hal/UnPhonePower.cpp
@@ -27,7 +27,7 @@ bool UnPhonePower::supportsMetric(MetricType type) const {
     }
 }
 
-bool UnPhonePower::getMetric(Power::MetricType type, Power::MetricData& data) {
+bool UnPhonePower::getMetric(MetricType type, MetricData& data) {
     switch (type) {
         using enum MetricType;
         case BatteryVoltage:
@@ -83,9 +83,9 @@ bool UnPhonePower::readBatteryVoltageSampled(uint32_t& output) const {
     }
 }
 
-static std::shared_ptr<Power> power;
+static std::shared_ptr<PowerDevice> power;
 
-std::shared_ptr<Power> unPhoneGetPower() {
+std::shared_ptr<PowerDevice> unPhoneGetPower() {
     if (power == nullptr) {
         power = std::make_shared<UnPhonePower>();
     }

--- a/Boards/UnPhone/Source/hal/UnPhonePower.h
+++ b/Boards/UnPhone/Source/hal/UnPhonePower.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Tactility/hal/power/Power.h>
+#include "Tactility/hal/power/PowerDevice.h"
 #include <memory>
 
-using tt::hal::power::Power;
+using tt::hal::power::PowerDevice;
 
-class UnPhonePower : public Power {
+class UnPhonePower : public PowerDevice {
 
 public:
 
@@ -16,7 +16,7 @@ public:
     std::string getDescription() const final { return "Power interface via XPT2046 voltage measurement"; }
 
     bool supportsMetric(MetricType type) const override;
-    bool getMetric(Power::MetricType type, Power::MetricData& data) override;
+    bool getMetric(MetricType type, MetricData& data) override;
 
 private:
 
@@ -24,4 +24,4 @@ private:
     bool readBatteryVoltageSampled(uint32_t& output) const;
 };
 
-std::shared_ptr<Power> unPhoneGetPower();
+std::shared_ptr<PowerDevice> unPhoneGetPower();

--- a/Boards/UnPhone/Source/hal/UnPhonePower.h
+++ b/Boards/UnPhone/Source/hal/UnPhonePower.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <Tactility/hal/Power.h>
+#include <Tactility/hal/power/Power.h>
 #include <memory>
 
-using namespace tt::hal;
+using tt::hal::power::Power;
 
 class UnPhonePower : public Power {
 

--- a/Boards/UnPhone/Source/hal/UnPhoneSdCard.cpp
+++ b/Boards/UnPhone/Source/hal/UnPhoneSdCard.cpp
@@ -1,7 +1,7 @@
 #include "UnPhoneSdCard.h"
 
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/sdcard/SpiSdCard.h>
+#include <Tactility/hal/sdcard/SpiSdCardDevice.h>
 
 #include <esp_vfs_fat.h>
 
@@ -10,15 +10,15 @@
 #define UNPHONE_LORA_PIN_CS GPIO_NUM_44
 #define UNPHONE_TOUCH_PIN_CS GPIO_NUM_38
 
-using tt::hal::sdcard::SpiSdCard;
+using tt::hal::sdcard::SpiSdCardDevice;
 
-std::shared_ptr<SdCard> createUnPhoneSdCard() {
-    auto* configuration = new SpiSdCard::Config(
+std::shared_ptr<SdCardDevice> createUnPhoneSdCard() {
+    auto* configuration = new SpiSdCardDevice::Config(
         UNPHONE_SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
         GPIO_NUM_NC,
-        SdCard::MountBehaviour::AtBoot,
+        SdCardDevice::MountBehaviour::AtBoot,
         tt::lvgl::getLvglSyncLockable(),
         {
             UNPHONE_LORA_PIN_CS,
@@ -27,9 +27,9 @@ std::shared_ptr<SdCard> createUnPhoneSdCard() {
         }
     );
 
-    auto* sdcard = (SdCard*) new SpiSdCard(
-        std::unique_ptr<SpiSdCard::Config>(configuration)
+    auto* sdcard = (SdCardDevice*) new SpiSdCardDevice(
+        std::unique_ptr<SpiSdCardDevice::Config>(configuration)
     );
 
-    return std::shared_ptr<SdCard>(sdcard);
+    return std::shared_ptr<SdCardDevice>(sdcard);
 }

--- a/Boards/UnPhone/Source/hal/UnPhoneSdCard.cpp
+++ b/Boards/UnPhone/Source/hal/UnPhoneSdCard.cpp
@@ -1,7 +1,7 @@
 #include "UnPhoneSdCard.h"
 
 #include <Tactility/lvgl/LvglSync.h>
-#include <Tactility/hal/SpiSdCard.h>
+#include <Tactility/hal/sdcard/SpiSdCard.h>
 
 #include <esp_vfs_fat.h>
 
@@ -10,8 +10,10 @@
 #define UNPHONE_LORA_PIN_CS GPIO_NUM_44
 #define UNPHONE_TOUCH_PIN_CS GPIO_NUM_38
 
+using tt::hal::sdcard::SpiSdCard;
+
 std::shared_ptr<SdCard> createUnPhoneSdCard() {
-    auto* configuration = new tt::hal::SpiSdCard::Config(
+    auto* configuration = new SpiSdCard::Config(
         UNPHONE_SDCARD_PIN_CS,
         GPIO_NUM_NC,
         GPIO_NUM_NC,

--- a/Boards/UnPhone/Source/hal/UnPhoneSdCard.h
+++ b/Boards/UnPhone/Source/hal/UnPhoneSdCard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Tactility/hal/sdcard/SdCard.h>
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 
-using tt::hal::sdcard::SdCard;
+using tt::hal::sdcard::SdCardDevice;
 
-std::shared_ptr<SdCard> createUnPhoneSdCard();
+std::shared_ptr<SdCardDevice> createUnPhoneSdCard();

--- a/Boards/UnPhone/Source/hal/UnPhoneSdCard.h
+++ b/Boards/UnPhone/Source/hal/UnPhoneSdCard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Tactility/hal/SdCard.h>
+#include <Tactility/hal/sdcard/SdCard.h>
 
-using namespace tt::hal;
+using tt::hal::sdcard::SdCard;
 
 std::shared_ptr<SdCard> createUnPhoneSdCard();

--- a/Boards/UnPhone/Source/hal/UnPhoneTouch.h
+++ b/Boards/UnPhone/Source/hal/UnPhoneTouch.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Tactility/hal/touch/Touch.h>
+#include "Tactility/hal/touch/TouchDevice.h"
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_panel_io_interface.h>
 #include <esp_lcd_touch.h>
 
-class UnPhoneTouch : public tt::hal::touch::Touch {
+class UnPhoneTouch : public tt::hal::touch::TouchDevice {
 
 private:
 

--- a/Boards/UnPhone/Source/hal/UnPhoneTouch.h
+++ b/Boards/UnPhone/Source/hal/UnPhoneTouch.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Tactility/hal/Touch.h>
+#include <Tactility/hal/touch/Touch.h>
 #include <Tactility/TactilityCore.h>
 #include <esp_lcd_panel_io_interface.h>
 #include <esp_lcd_touch.h>
 
-class UnPhoneTouch : public tt::hal::Touch {
+class UnPhoneTouch : public tt::hal::touch::Touch {
 
 private:
 

--- a/Drivers/ILI934x/Source/Ili934xDisplay.h
+++ b/Drivers/ILI934x/Source/Ili934xDisplay.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Tactility/hal/display/Display.h>
+#include "Tactility/hal/display/DisplayDevice.h"
 
 #include <driver/spi_common.h>
 #include <driver/gpio.h>
@@ -9,7 +9,7 @@
 #include <functional>
 #include <lvgl.h>
 
-class Ili934xDisplay final : public tt::hal::display::Display {
+class Ili934xDisplay final : public tt::hal::display::DisplayDevice {
 
 public:
 
@@ -23,7 +23,7 @@ public:
             gpio_num_t dcPin,
             unsigned int horizontalResolution,
             unsigned int verticalResolution,
-            std::shared_ptr<tt::hal::touch::Touch> touch
+            std::shared_ptr<tt::hal::touch::TouchDevice> touch
         ) : spiBusHandle(spi_bus_handle),
             csPin(csPin),
             dcPin(dcPin),
@@ -44,7 +44,7 @@ public:
         bool mirrorY = false;
         bool invertColor = true;
         uint32_t bufferSize = 0; // Size in pixel count. 0 means default, which is 1/10 of the screen size
-        std::shared_ptr<tt::hal::touch::Touch> touch;
+        std::shared_ptr<tt::hal::touch::TouchDevice> touch;
         std::function<void(uint8_t)> _Nullable backlightDutyFunction = nullptr;
     };
 
@@ -68,7 +68,7 @@ public:
 
     bool stop() final;
 
-    std::shared_ptr<tt::hal::touch::Touch> _Nullable createTouch() final { return configuration->touch; }
+    std::shared_ptr<tt::hal::touch::TouchDevice> _Nullable createTouch() final { return configuration->touch; }
 
     void setBacklightDuty(uint8_t backlightDuty) final {
         if (configuration->backlightDutyFunction != nullptr) {
@@ -84,4 +84,4 @@ public:
     lv_display_t* _Nullable getLvglDisplay() const final { return displayHandle; }
 };
 
-std::shared_ptr<tt::hal::display::Display> createDisplay();
+std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay();

--- a/Drivers/ILI934x/Source/Ili934xDisplay.h
+++ b/Drivers/ILI934x/Source/Ili934xDisplay.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Tactility/hal/Display.h>
+#include <Tactility/hal/display/Display.h>
 
 #include <driver/spi_common.h>
 #include <driver/gpio.h>
@@ -9,7 +9,7 @@
 #include <functional>
 #include <lvgl.h>
 
-class Ili934xDisplay final : public tt::hal::Display {
+class Ili934xDisplay final : public tt::hal::display::Display {
 
 public:
 
@@ -23,7 +23,7 @@ public:
             gpio_num_t dcPin,
             unsigned int horizontalResolution,
             unsigned int verticalResolution,
-            std::shared_ptr<tt::hal::Touch> touch
+            std::shared_ptr<tt::hal::touch::Touch> touch
         ) : spiBusHandle(spi_bus_handle),
             csPin(csPin),
             dcPin(dcPin),
@@ -44,7 +44,7 @@ public:
         bool mirrorY = false;
         bool invertColor = true;
         uint32_t bufferSize = 0; // Size in pixel count. 0 means default, which is 1/10 of the screen size
-        std::shared_ptr<tt::hal::Touch> touch;
+        std::shared_ptr<tt::hal::touch::Touch> touch;
         std::function<void(uint8_t)> _Nullable backlightDutyFunction = nullptr;
     };
 
@@ -68,7 +68,7 @@ public:
 
     bool stop() final;
 
-    std::shared_ptr<tt::hal::Touch> _Nullable createTouch() final { return configuration->touch; }
+    std::shared_ptr<tt::hal::touch::Touch> _Nullable createTouch() final { return configuration->touch; }
 
     void setBacklightDuty(uint8_t backlightDuty) final {
         if (configuration->backlightDutyFunction != nullptr) {
@@ -84,4 +84,4 @@ public:
     lv_display_t* _Nullable getLvglDisplay() const final { return displayHandle; }
 };
 
-std::shared_ptr<tt::hal::Display> createDisplay();
+std::shared_ptr<tt::hal::display::Display> createDisplay();

--- a/Tactility/Source/app/ElfApp.cpp
+++ b/Tactility/Source/app/ElfApp.cpp
@@ -4,9 +4,9 @@
 #include "Tactility/file/File.h"
 #include "Tactility/service/loader/Loader.h"
 
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 #include <Tactility/Log.h>
 #include <Tactility/StringUtils.h>
-#include <Tactility/hal/sdcard/SdCard.h>
 
 #include "esp_elf.h"
 

--- a/Tactility/Source/app/ElfApp.cpp
+++ b/Tactility/Source/app/ElfApp.cpp
@@ -6,7 +6,7 @@
 
 #include <Tactility/Log.h>
 #include <Tactility/StringUtils.h>
-#include <Tactility/hal/SdCard.h>
+#include <Tactility/hal/sdcard/SdCard.h>
 
 #include "esp_elf.h"
 
@@ -50,7 +50,7 @@ private:
         assert(elfFileData == nullptr);
 
         size_t size = 0;
-        hal::withSdCardLock<void>(filePath, [this, &size](){
+        hal::sdcard::withSdCardLock<void>(filePath, [this, &size](){
             elfFileData = file::readBinary(filePath, size);
         });
 

--- a/Tactility/Source/app/boot/Boot.cpp
+++ b/Tactility/Source/app/boot/Boot.cpp
@@ -5,8 +5,8 @@
 #include "Tactility/service/loader/Loader.h"
 #include "Tactility/lvgl/Style.h"
 
+#include "Tactility/hal/display/DisplayDevice.h"
 #include <Tactility/TactilityPrivate.h>
-#include <Tactility/hal/display/Display.h>
 #include <Tactility/hal/usb/Usb.h>
 #include <Tactility/kernel/SystemEvents.h>
 
@@ -24,8 +24,8 @@
 
 namespace tt::app::boot {
 
-static std::shared_ptr<tt::hal::display::Display> getHalDisplay() {
-    return hal::findFirstDevice<hal::display::Display>(hal::Device::Type::Display);
+static std::shared_ptr<tt::hal::display::DisplayDevice> getHalDisplay() {
+    return hal::findFirstDevice<hal::display::DisplayDevice>(hal::Device::Type::Display);
 }
 
 class BootApp : public App {
@@ -57,7 +57,6 @@ private:
             TickType_t ticks_passed = end_time - start_time;
             TickType_t minimum_ticks = (CONFIG_TT_SPLASH_DURATION / portTICK_PERIOD_MS);
             if (minimum_ticks > ticks_passed) {
-                TT_LOG_I(TAG, "Remaining delay: %lu", minimum_ticks - ticks_passed);
                 kernel::delayTicks(minimum_ticks - ticks_passed);
             }
 

--- a/Tactility/Source/app/boot/Boot.cpp
+++ b/Tactility/Source/app/boot/Boot.cpp
@@ -6,7 +6,7 @@
 #include "Tactility/lvgl/Style.h"
 
 #include <Tactility/TactilityPrivate.h>
-#include <Tactility/hal/Display.h>
+#include <Tactility/hal/display/Display.h>
 #include <Tactility/hal/usb/Usb.h>
 #include <Tactility/kernel/SystemEvents.h>
 
@@ -24,8 +24,8 @@
 
 namespace tt::app::boot {
 
-static std::shared_ptr<tt::hal::Display> getHalDisplay() {
-    return hal::findFirstDevice<hal::Display>(hal::Device::Type::Display);
+static std::shared_ptr<tt::hal::display::Display> getHalDisplay() {
+    return hal::findFirstDevice<hal::display::Display>(hal::Device::Type::Display);
 }
 
 class BootApp : public App {

--- a/Tactility/Source/app/display/Display.cpp
+++ b/Tactility/Source/app/display/Display.cpp
@@ -1,6 +1,6 @@
 #include "Tactility/app/display/DisplaySettings.h"
 
-#include "Tactility/hal/Display.h"
+#include "Tactility/hal/display/Display.h"
 #include "Tactility/lvgl/Toolbar.h"
 
 #include <Tactility/Assets.h>
@@ -22,8 +22,8 @@ static uint8_t gamma = 255;
 #define ROTATION_270 2
 #define ROTATION_90 3
 
-static std::shared_ptr<tt::hal::Display> getHalDisplay() {
-    return hal::findFirstDevice<hal::Display>(hal::Device::Type::Display);
+static std::shared_ptr<tt::hal::display::Display> getHalDisplay() {
+    return hal::findFirstDevice<hal::display::Display>(hal::Device::Type::Display);
 }
 
 static void onBacklightSliderEvent(lv_event_t* event) {
@@ -46,7 +46,7 @@ static void onGammaSliderEvent(lv_event_t* event) {
     auto* slider = static_cast<lv_obj_t*>(lv_event_get_target(event));
     auto* lvgl_display = lv_display_get_default();
     assert(lvgl_display != nullptr);
-    auto* hal_display = (tt::hal::Display*)lv_display_get_user_data(lvgl_display);
+    auto* hal_display = (tt::hal::display::Display*)lv_display_get_user_data(lvgl_display);
     assert(hal_display != nullptr);
 
     if (hal_display->getGammaCurveCount() > 0) {

--- a/Tactility/Source/app/display/Display.cpp
+++ b/Tactility/Source/app/display/Display.cpp
@@ -1,6 +1,6 @@
 #include "Tactility/app/display/DisplaySettings.h"
 
-#include "Tactility/hal/display/Display.h"
+#include "Tactility/hal/display/DisplayDevice.h"
 #include "Tactility/lvgl/Toolbar.h"
 
 #include <Tactility/Assets.h>
@@ -22,8 +22,8 @@ static uint8_t gamma = 255;
 #define ROTATION_270 2
 #define ROTATION_90 3
 
-static std::shared_ptr<tt::hal::display::Display> getHalDisplay() {
-    return hal::findFirstDevice<hal::display::Display>(hal::Device::Type::Display);
+static std::shared_ptr<tt::hal::display::DisplayDevice> getHalDisplay() {
+    return hal::findFirstDevice<hal::display::DisplayDevice>(hal::Device::Type::Display);
 }
 
 static void onBacklightSliderEvent(lv_event_t* event) {
@@ -46,7 +46,7 @@ static void onGammaSliderEvent(lv_event_t* event) {
     auto* slider = static_cast<lv_obj_t*>(lv_event_get_target(event));
     auto* lvgl_display = lv_display_get_default();
     assert(lvgl_display != nullptr);
-    auto* hal_display = (tt::hal::display::Display*)lv_display_get_user_data(lvgl_display);
+    auto* hal_display = (tt::hal::display::DisplayDevice*)lv_display_get_user_data(lvgl_display);
     assert(hal_display != nullptr);
 
     if (hal_display->getGammaCurveCount() > 0) {

--- a/Tactility/Source/app/files/State.cpp
+++ b/Tactility/Source/app/files/State.cpp
@@ -1,9 +1,9 @@
 #include "Tactility/app/files/State.h"
 #include "Tactility/app/files/FileUtils.h"
 
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 #include <Tactility/Log.h>
 #include <Tactility/Partitions.h>
-#include <Tactility/hal/sdcard/SdCard.h>
 #include <Tactility/kernel/Kernel.h>
 
 #include <cstring>
@@ -59,10 +59,10 @@ bool State::setEntriesForPath(const std::string& path) {
             .d_name = DATA_PARTITION_NAME
         });
 
-        auto sdcards = tt::hal::findDevices<hal::sdcard::SdCard>(hal::Device::Type::SdCard);
+        auto sdcards = tt::hal::findDevices<hal::sdcard::SdCardDevice>(hal::Device::Type::SdCard);
         for (auto& sdcard : sdcards) {
             auto state = sdcard->getState();
-            if (state == hal::sdcard::SdCard::State::Mounted) {
+            if (state == hal::sdcard::SdCardDevice::State::Mounted) {
                 auto mount_name = sdcard->getMountPath().substr(1);
                 auto dir_entry = dirent {
                     .d_ino = 2,

--- a/Tactility/Source/app/files/State.cpp
+++ b/Tactility/Source/app/files/State.cpp
@@ -3,7 +3,7 @@
 
 #include <Tactility/Log.h>
 #include <Tactility/Partitions.h>
-#include <Tactility/hal/SdCard.h>
+#include <Tactility/hal/sdcard/SdCard.h>
 #include <Tactility/kernel/Kernel.h>
 
 #include <cstring>
@@ -59,10 +59,10 @@ bool State::setEntriesForPath(const std::string& path) {
             .d_name = DATA_PARTITION_NAME
         });
 
-        auto sdcards = tt::hal::findDevices<hal::SdCard>(hal::Device::Type::SdCard);
+        auto sdcards = tt::hal::findDevices<hal::sdcard::SdCard>(hal::Device::Type::SdCard);
         for (auto& sdcard : sdcards) {
             auto state = sdcard->getState();
-            if (state == hal::SdCard::State::Mounted) {
+            if (state == hal::sdcard::SdCard::State::Mounted) {
                 auto mount_name = sdcard->getMountPath().substr(1);
                 auto dir_entry = dirent {
                     .d_ino = 2,

--- a/Tactility/Source/app/power/Power.cpp
+++ b/Tactility/Source/app/power/Power.cpp
@@ -4,10 +4,10 @@
 #include "Tactility/lvgl/Toolbar.h"
 #include "Tactility/service/loader/Loader.h"
 
-#include <Tactility/hal/Device.h>
-#include <Tactility/hal/power/Power.h>
+#include "Tactility/hal/power/PowerDevice.h"
 #include <Tactility/Assets.h>
 #include <Tactility/Timer.h>
+#include <Tactility/hal/Device.h>
 
 #include <lvgl.h>
 
@@ -35,7 +35,7 @@ private:
 
     Timer update_timer = Timer(Timer::Type::Periodic, &onTimer, nullptr);
 
-    std::shared_ptr<hal::power::Power> power;
+    std::shared_ptr<hal::power::PowerDevice> power;
 
     lv_obj_t* enableLabel = nullptr;
     lv_obj_t* enableSwitch = nullptr;
@@ -71,8 +71,8 @@ private:
 
     void updateUi() {
         const char* charge_state;
-        hal::power::Power::MetricData metric_data;
-        if (power->getMetric(hal::power::Power::MetricType::IsCharging, metric_data)) {
+        hal::power::PowerDevice::MetricData metric_data;
+        if (power->getMetric(hal::power::PowerDevice::MetricType::IsCharging, metric_data)) {
             charge_state = metric_data.valueAsBool ? "yes" : "no";
         } else {
             charge_state = "N/A";
@@ -80,7 +80,7 @@ private:
 
         uint8_t charge_level;
         bool charge_level_scaled_set = false;
-        if (power->getMetric(hal::power::Power::MetricType::ChargeLevel, metric_data)) {
+        if (power->getMetric(hal::power::PowerDevice::MetricType::ChargeLevel, metric_data)) {
             charge_level = metric_data.valueAsUint8;
             charge_level_scaled_set = true;
         }
@@ -90,14 +90,14 @@ private:
 
         int32_t current;
         bool current_set = false;
-        if (power->getMetric(hal::power::Power::MetricType::Current, metric_data)) {
+        if (power->getMetric(hal::power::PowerDevice::MetricType::Current, metric_data)) {
             current = metric_data.valueAsInt32;
             current_set = true;
         }
 
         uint32_t battery_voltage;
         bool battery_voltage_set = false;
-        if (power->getMetric(hal::power::Power::MetricType::BatteryVoltage, metric_data)) {
+        if (power->getMetric(hal::power::PowerDevice::MetricType::BatteryVoltage, metric_data)) {
             battery_voltage = metric_data.valueAsUint32;
             battery_voltage_set = true;
         }
@@ -139,7 +139,7 @@ private:
 public:
 
     void onCreate(AppContext& app) override {
-        power = hal::findFirstDevice<hal::power::Power>(hal::Device::Type::Power);
+        power = hal::findFirstDevice<hal::power::PowerDevice>(hal::Device::Type::Power);
     }
 
     void onShow(AppContext& app, lv_obj_t* parent) override {

--- a/Tactility/Source/app/power/Power.cpp
+++ b/Tactility/Source/app/power/Power.cpp
@@ -5,7 +5,7 @@
 #include "Tactility/service/loader/Loader.h"
 
 #include <Tactility/hal/Device.h>
-#include <Tactility/hal/Power.h>
+#include <Tactility/hal/power/Power.h>
 #include <Tactility/Assets.h>
 #include <Tactility/Timer.h>
 
@@ -35,7 +35,7 @@ private:
 
     Timer update_timer = Timer(Timer::Type::Periodic, &onTimer, nullptr);
 
-    std::shared_ptr<hal::Power> power;
+    std::shared_ptr<hal::power::Power> power;
 
     lv_obj_t* enableLabel = nullptr;
     lv_obj_t* enableSwitch = nullptr;
@@ -71,8 +71,8 @@ private:
 
     void updateUi() {
         const char* charge_state;
-        hal::Power::MetricData metric_data;
-        if (power->getMetric(hal::Power::MetricType::IsCharging, metric_data)) {
+        hal::power::Power::MetricData metric_data;
+        if (power->getMetric(hal::power::Power::MetricType::IsCharging, metric_data)) {
             charge_state = metric_data.valueAsBool ? "yes" : "no";
         } else {
             charge_state = "N/A";
@@ -80,7 +80,7 @@ private:
 
         uint8_t charge_level;
         bool charge_level_scaled_set = false;
-        if (power->getMetric(hal::Power::MetricType::ChargeLevel, metric_data)) {
+        if (power->getMetric(hal::power::Power::MetricType::ChargeLevel, metric_data)) {
             charge_level = metric_data.valueAsUint8;
             charge_level_scaled_set = true;
         }
@@ -90,14 +90,14 @@ private:
 
         int32_t current;
         bool current_set = false;
-        if (power->getMetric(hal::Power::MetricType::Current, metric_data)) {
+        if (power->getMetric(hal::power::Power::MetricType::Current, metric_data)) {
             current = metric_data.valueAsInt32;
             current_set = true;
         }
 
         uint32_t battery_voltage;
         bool battery_voltage_set = false;
-        if (power->getMetric(hal::Power::MetricType::BatteryVoltage, metric_data)) {
+        if (power->getMetric(hal::power::Power::MetricType::BatteryVoltage, metric_data)) {
             battery_voltage = metric_data.valueAsUint32;
             battery_voltage_set = true;
         }
@@ -139,7 +139,7 @@ private:
 public:
 
     void onCreate(AppContext& app) override {
-        power = hal::findFirstDevice<hal::Power>(hal::Device::Type::Power);
+        power = hal::findFirstDevice<hal::power::Power>(hal::Device::Type::Power);
     }
 
     void onShow(AppContext& app, lv_obj_t* parent) override {

--- a/Tactility/Source/app/screenshot/Screenshot.cpp
+++ b/Tactility/Source/app/screenshot/Screenshot.cpp
@@ -206,7 +206,7 @@ void ScreenshotApp::createFilePathWidgets(lv_obj_t* parent) {
     lv_obj_set_flex_grow(pathTextArea, 1);
     if (kernel::getPlatform() == kernel::PlatformEsp) {
         auto sdcard = tt::hal::getConfiguration()->sdcard;
-        if (sdcard != nullptr && sdcard->getState() == hal::SdCard::State::Mounted) {
+        if (sdcard != nullptr && sdcard->getState() == hal::sdcard::SdCard::State::Mounted) {
             lv_textarea_set_text(pathTextArea, "A:/sdcard");
         } else {
             lv_textarea_set_text(pathTextArea, "Error: no SD card");

--- a/Tactility/Source/app/screenshot/Screenshot.cpp
+++ b/Tactility/Source/app/screenshot/Screenshot.cpp
@@ -205,9 +205,13 @@ void ScreenshotApp::createFilePathWidgets(lv_obj_t* parent) {
     lv_textarea_set_one_line(pathTextArea, true);
     lv_obj_set_flex_grow(pathTextArea, 1);
     if (kernel::getPlatform() == kernel::PlatformEsp) {
-        auto sdcard = tt::hal::getConfiguration()->sdcard;
-        if (sdcard != nullptr && sdcard->getState() == hal::sdcard::SdCard::State::Mounted) {
-            lv_textarea_set_text(pathTextArea, "A:/sdcard");
+        auto sdcard_devices = tt::hal::findDevices<tt::hal::sdcard::SdCardDevice>(tt::hal::Device::Type::SdCard);
+        if (sdcard_devices.size() > 1) {
+            TT_LOG_W(TAG, "Found multiple SD card devices - picking first");
+        }
+        if (!sdcard_devices.empty() && sdcard_devices.front()->isMounted()) {
+            std::string lvgl_mount_path = "A:" + sdcard_devices.front()->getMountPath();
+            lv_textarea_set_text(pathTextArea, lvgl_mount_path.c_str());
         } else {
             lv_textarea_set_text(pathTextArea, "Error: no SD card");
         }

--- a/Tactility/Source/lvgl/Init.cpp
+++ b/Tactility/Source/lvgl/Init.cpp
@@ -1,10 +1,10 @@
 #include "Tactility/app/display/DisplaySettings.h"
 #include "Tactility/lvgl/LvglKeypad.h"
 
+#include "Tactility/hal/display/DisplayDevice.h"
+#include "Tactility/hal/touch/TouchDevice.h"
 #include <Tactility/hal/Configuration.h>
-#include <Tactility/hal/display/Display.h>
-#include <Tactility/hal/keyboard/Keyboard.h>
-#include <Tactility/hal/touch/Touch.h>
+#include <Tactility/hal/keyboard/KeyboardDevice.h>
 #include <Tactility/kernel/SystemEvents.h>
 
 #ifdef ESP_PLATFORM
@@ -17,7 +17,7 @@ namespace tt::lvgl {
 
 #define TAG "lvgl_init"
 
-static std::shared_ptr<tt::hal::display::Display> initDisplay(const hal::Configuration& config) {
+static std::shared_ptr<tt::hal::display::DisplayDevice> initDisplay(const hal::Configuration& config) {
     assert(config.createDisplay);
     auto display = config.createDisplay();
     assert(display != nullptr);
@@ -48,7 +48,7 @@ static std::shared_ptr<tt::hal::display::Display> initDisplay(const hal::Configu
     return display;
 }
 
-static bool initTouch(const std::shared_ptr<hal::display::Display>& display, const std::shared_ptr<hal::touch::Touch>& touch) {
+static bool initTouch(const std::shared_ptr<hal::display::DisplayDevice>& display, const std::shared_ptr<hal::touch::TouchDevice>& touch) {
     TT_LOG_I(TAG, "Touch init");
     assert(display);
     assert(touch);
@@ -60,7 +60,7 @@ static bool initTouch(const std::shared_ptr<hal::display::Display>& display, con
     }
 }
 
-static bool initKeyboard(const std::shared_ptr<hal::display::Display>& display, const std::shared_ptr<hal::keyboard::Keyboard>& keyboard) {
+static bool initKeyboard(const std::shared_ptr<hal::display::DisplayDevice>& display, const std::shared_ptr<hal::keyboard::KeyboardDevice>& keyboard) {
     TT_LOG_I(TAG, "Keyboard init");
     assert(display);
     assert(keyboard);

--- a/Tactility/Source/lvgl/Init.cpp
+++ b/Tactility/Source/lvgl/Init.cpp
@@ -2,9 +2,9 @@
 #include "Tactility/lvgl/LvglKeypad.h"
 
 #include <Tactility/hal/Configuration.h>
-#include <Tactility/hal/Display.h>
-#include <Tactility/hal/Keyboard.h>
-#include <Tactility/hal/Touch.h>
+#include <Tactility/hal/display/Display.h>
+#include <Tactility/hal/keyboard/Keyboard.h>
+#include <Tactility/hal/touch/Touch.h>
 #include <Tactility/kernel/SystemEvents.h>
 
 #ifdef ESP_PLATFORM
@@ -17,7 +17,7 @@ namespace tt::lvgl {
 
 #define TAG "lvgl_init"
 
-static std::shared_ptr<tt::hal::Display> initDisplay(const hal::Configuration& config) {
+static std::shared_ptr<tt::hal::display::Display> initDisplay(const hal::Configuration& config) {
     assert(config.createDisplay);
     auto display = config.createDisplay();
     assert(display != nullptr);
@@ -48,7 +48,7 @@ static std::shared_ptr<tt::hal::Display> initDisplay(const hal::Configuration& c
     return display;
 }
 
-static bool initTouch(const std::shared_ptr<hal::Display>& display, const std::shared_ptr<hal::Touch>& touch) {
+static bool initTouch(const std::shared_ptr<hal::display::Display>& display, const std::shared_ptr<hal::touch::Touch>& touch) {
     TT_LOG_I(TAG, "Touch init");
     assert(display);
     assert(touch);
@@ -60,7 +60,7 @@ static bool initTouch(const std::shared_ptr<hal::Display>& display, const std::s
     }
 }
 
-static bool initKeyboard(const std::shared_ptr<hal::Display>& display, const std::shared_ptr<hal::Keyboard>& keyboard) {
+static bool initKeyboard(const std::shared_ptr<hal::display::Display>& display, const std::shared_ptr<hal::keyboard::Keyboard>& keyboard) {
     TT_LOG_I(TAG, "Keyboard init");
     assert(display);
     assert(keyboard);

--- a/Tactility/Source/service/statusbar/Statusbar.cpp
+++ b/Tactility/Source/service/statusbar/Statusbar.cpp
@@ -3,8 +3,8 @@
 
 #include <Tactility/Mutex.h>
 #include <Tactility/Timer.h>
-#include <Tactility/hal/Power.h>
-#include <Tactility/hal/SdCard.h>
+#include <Tactility/hal/power/Power.h>
+#include <Tactility/hal/sdcard/SdCard.h>
 #include <Tactility/service/ServiceContext.h>
 #include <Tactility/service/wifi/Wifi.h>
 #include <Tactility/service/ServiceRegistry.h>
@@ -70,9 +70,9 @@ static const char* getWifiStatusIcon(wifi::RadioState state, bool secure) {
     }
 }
 
-static const char* getSdCardStatusIcon(hal::SdCard::State state) {
+static const char* getSdCardStatusIcon(hal::sdcard::SdCard::State state) {
     switch (state) {
-        using enum hal::SdCard::State;
+        using enum hal::sdcard::SdCard::State;
         case Mounted:
             return STATUSBAR_ICON_SDCARD;
         case Error:
@@ -92,8 +92,8 @@ static _Nullable const char* getPowerStatusIcon() {
 
     auto power = get_power();
 
-    hal::Power::MetricData charge_level;
-    if (!power->getMetric(hal::Power::MetricType::ChargeLevel, charge_level)) {
+    hal::power::Power::MetricData charge_level;
+    if (!power->getMetric(hal::power::Power::MetricType::ChargeLevel, charge_level)) {
         return nullptr;
     }
 
@@ -181,7 +181,7 @@ private:
         auto sdcard = tt::hal::getConfiguration()->sdcard;
         if (sdcard != nullptr) {
             auto state = sdcard->getState();
-            if (state != hal::SdCard::State::Unknown) {
+            if (state != hal::sdcard::SdCard::State::Unknown) {
                 auto* desired_icon = getSdCardStatusIcon(state);
                 if (sdcard_last_icon != desired_icon) {
                     auto icon_path = paths->getSystemPathLvgl(desired_icon);

--- a/Tactility/Source/service/statusbar/Statusbar.cpp
+++ b/Tactility/Source/service/statusbar/Statusbar.cpp
@@ -1,15 +1,15 @@
 #include "Tactility/lvgl/Statusbar.h"
 #include "Tactility/lvgl/LvglSync.h"
 
+#include "Tactility/hal/power/PowerDevice.h"
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 #include <Tactility/Mutex.h>
-#include <Tactility/Timer.h>
-#include <Tactility/hal/power/Power.h>
-#include <Tactility/hal/sdcard/SdCard.h>
-#include <Tactility/service/ServiceContext.h>
-#include <Tactility/service/wifi/Wifi.h>
-#include <Tactility/service/ServiceRegistry.h>
 #include <Tactility/Tactility.h>
 #include <Tactility/TactilityHeadless.h>
+#include <Tactility/Timer.h>
+#include <Tactility/service/ServiceContext.h>
+#include <Tactility/service/ServiceRegistry.h>
+#include <Tactility/service/wifi/Wifi.h>
 
 namespace tt::service::statusbar {
 
@@ -70,9 +70,9 @@ static const char* getWifiStatusIcon(wifi::RadioState state, bool secure) {
     }
 }
 
-static const char* getSdCardStatusIcon(hal::sdcard::SdCard::State state) {
+static const char* getSdCardStatusIcon(hal::sdcard::SdCardDevice::State state) {
     switch (state) {
-        using enum hal::sdcard::SdCard::State;
+        using enum hal::sdcard::SdCardDevice::State;
         case Mounted:
             return STATUSBAR_ICON_SDCARD;
         case Error:
@@ -92,8 +92,8 @@ static _Nullable const char* getPowerStatusIcon() {
 
     auto power = get_power();
 
-    hal::power::Power::MetricData charge_level;
-    if (!power->getMetric(hal::power::Power::MetricType::ChargeLevel, charge_level)) {
+    hal::power::PowerDevice::MetricData charge_level;
+    if (!power->getMetric(hal::power::PowerDevice::MetricType::ChargeLevel, charge_level)) {
         return nullptr;
     }
 
@@ -181,7 +181,7 @@ private:
         auto sdcard = tt::hal::getConfiguration()->sdcard;
         if (sdcard != nullptr) {
             auto state = sdcard->getState();
-            if (state != hal::sdcard::SdCard::State::Unknown) {
+            if (state != hal::sdcard::SdCardDevice::State::Unknown) {
                 auto* desired_icon = getSdCardStatusIcon(state);
                 if (sdcard_last_icon != desired_icon) {
                     auto icon_path = paths->getSystemPathLvgl(desired_icon);

--- a/TactilityHeadless/Include/Tactility/hal/Configuration.h
+++ b/TactilityHeadless/Include/Tactility/hal/Configuration.h
@@ -1,21 +1,21 @@
 #pragma once
 
-#include "sdcard/SdCard.h"
-#include "i2c/I2c.h"
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 #include "Tactility/hal/spi/Spi.h"
 #include "Tactility/hal/uart/Uart.h"
+#include "i2c/I2c.h"
 
 namespace tt::hal {
 
 typedef bool (*InitBoot)();
 
-namespace display { class Display; }
-namespace keyboard { class Keyboard; }
-namespace power { class Power; }
+namespace display { class DisplayDevice; }
+namespace keyboard { class KeyboardDevice; }
+namespace power { class PowerDevice; }
 
-typedef std::shared_ptr<display::Display> (*CreateDisplay)();
-typedef std::shared_ptr<keyboard::Keyboard> (*CreateKeyboard)();
-typedef std::shared_ptr<power::Power> (*CreatePower)();
+typedef std::shared_ptr<display::DisplayDevice> (*CreateDisplay)();
+typedef std::shared_ptr<keyboard::KeyboardDevice> (*CreateKeyboard)();
+typedef std::shared_ptr<power::PowerDevice> (*CreatePower)();
 
 enum class LvglInit {
     Default,
@@ -39,7 +39,7 @@ struct Configuration {
     const CreateKeyboard _Nullable createKeyboard = nullptr;
 
     /** An optional SD card interface. */
-    const std::shared_ptr<sdcard::SdCard> _Nullable sdcard = nullptr;
+    const std::shared_ptr<sdcard::SdCardDevice> _Nullable sdcard = nullptr;
 
     /** An optional power interface for battery or other power delivery. */
     const CreatePower _Nullable power = nullptr;

--- a/TactilityHeadless/Include/Tactility/hal/Configuration.h
+++ b/TactilityHeadless/Include/Tactility/hal/Configuration.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "./SdCard.h"
-#include "./i2c/I2c.h"
+#include "sdcard/SdCard.h"
+#include "i2c/I2c.h"
 #include "Tactility/hal/spi/Spi.h"
 #include "Tactility/hal/uart/Uart.h"
 
@@ -9,12 +9,13 @@ namespace tt::hal {
 
 typedef bool (*InitBoot)();
 
-class Display;
-class Keyboard;
-class Power;
-typedef std::shared_ptr<Display> (*CreateDisplay)();
-typedef std::shared_ptr<Keyboard> (*CreateKeyboard)();
-typedef std::shared_ptr<Power> (*CreatePower)();
+namespace display { class Display; }
+namespace keyboard { class Keyboard; }
+namespace power { class Power; }
+
+typedef std::shared_ptr<display::Display> (*CreateDisplay)();
+typedef std::shared_ptr<keyboard::Keyboard> (*CreateKeyboard)();
+typedef std::shared_ptr<power::Power> (*CreatePower)();
 
 enum class LvglInit {
     Default,
@@ -38,7 +39,7 @@ struct Configuration {
     const CreateKeyboard _Nullable createKeyboard = nullptr;
 
     /** An optional SD card interface. */
-    const std::shared_ptr<SdCard> _Nullable sdcard = nullptr;
+    const std::shared_ptr<sdcard::SdCard> _Nullable sdcard = nullptr;
 
     /** An optional power interface for battery or other power delivery. */
     const CreatePower _Nullable power = nullptr;

--- a/TactilityHeadless/Include/Tactility/hal/display/Display.h
+++ b/TactilityHeadless/Include/Tactility/hal/display/Display.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include "Device.h"
+#include "../Device.h"
 
 #include <lvgl.h>
 
-namespace tt::hal {
-
+namespace tt::hal::touch {
 class Touch;
+}
+
+namespace tt::hal::display {
 
 class Display : public Device {
 
@@ -21,7 +23,7 @@ public:
     virtual bool isPoweredOn() const { return true; }
     virtual bool supportsPowerControl() const { return false; }
 
-    virtual std::shared_ptr<Touch> _Nullable createTouch() = 0;
+    virtual std::shared_ptr<touch::Touch> _Nullable createTouch() = 0;
 
     /** Set a value in the range [0, 255] */
     virtual void setBacklightDuty(uint8_t backlightDuty) { /* NO-OP */ }
@@ -35,4 +37,4 @@ public:
     virtual lv_display_t* _Nullable getLvglDisplay() const = 0;
 };
 
-}
+} // namespace tt::hal::display

--- a/TactilityHeadless/Include/Tactility/hal/display/DisplayDevice.h
+++ b/TactilityHeadless/Include/Tactility/hal/display/DisplayDevice.h
@@ -5,12 +5,12 @@
 #include <lvgl.h>
 
 namespace tt::hal::touch {
-class Touch;
+class TouchDevice;
 }
 
 namespace tt::hal::display {
 
-class Display : public Device {
+class DisplayDevice : public Device {
 
 public:
 
@@ -23,7 +23,7 @@ public:
     virtual bool isPoweredOn() const { return true; }
     virtual bool supportsPowerControl() const { return false; }
 
-    virtual std::shared_ptr<touch::Touch> _Nullable createTouch() = 0;
+    virtual std::shared_ptr<touch::TouchDevice> _Nullable createTouch() = 0;
 
     /** Set a value in the range [0, 255] */
     virtual void setBacklightDuty(uint8_t backlightDuty) { /* NO-OP */ }

--- a/TactilityHeadless/Include/Tactility/hal/keyboard/Keyboard.h
+++ b/TactilityHeadless/Include/Tactility/hal/keyboard/Keyboard.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "Device.h"
+#include "../Device.h"
 
 #include <lvgl.h>
 
-namespace tt::hal {
+namespace tt::hal::keyboard {
 
 class Display;
 

--- a/TactilityHeadless/Include/Tactility/hal/keyboard/KeyboardDevice.h
+++ b/TactilityHeadless/Include/Tactility/hal/keyboard/KeyboardDevice.h
@@ -4,18 +4,19 @@
 
 #include <lvgl.h>
 
-namespace tt::hal::touch {
+namespace tt::hal::keyboard {
 
 class Display;
 
-class Touch : public Device {
+class KeyboardDevice : public Device {
 
 public:
 
-    Type getType() const override { return Type::SdCard; }
+    Type getType() const override { return Type::Keyboard; }
 
     virtual bool start(lv_display_t* display) = 0;
     virtual bool stop() = 0;
+    virtual bool isAttached() const = 0;
 
     virtual lv_indev_t* _Nullable getLvglIndev() = 0;
 };

--- a/TactilityHeadless/Include/Tactility/hal/power/Power.h
+++ b/TactilityHeadless/Include/Tactility/hal/power/Power.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Device.h"
+#include "../Device.h"
 #include <cstdint>
 
-namespace tt::hal {
+namespace tt::hal::power {
 
 class Power : public Device {
 

--- a/TactilityHeadless/Include/Tactility/hal/power/PowerDevice.h
+++ b/TactilityHeadless/Include/Tactility/hal/power/PowerDevice.h
@@ -5,12 +5,12 @@
 
 namespace tt::hal::power {
 
-class Power : public Device {
+class PowerDevice : public Device {
 
 public:
 
-    Power() = default;
-    ~Power() override = default;
+    PowerDevice() = default;
+    ~PowerDevice() override = default;
 
     Type getType() const override { return Type::Power; }
 
@@ -34,7 +34,7 @@ public:
     /**
      * @return false when metric is not supported or (temporarily) not available.
      */
-    virtual bool getMetric(Power::MetricType type, MetricData& data) = 0;
+    virtual bool getMetric(MetricType type, MetricData& data) = 0;
 
     virtual bool supportsChargeControl() const { return false; }
     virtual bool isAllowedToCharge() const { return false; }

--- a/TactilityHeadless/Include/Tactility/hal/sdcard/SdCard.h
+++ b/TactilityHeadless/Include/Tactility/hal/sdcard/SdCard.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "Device.h"
+#include "../Device.h"
 
 #include <Tactility/TactilityCore.h>
 
-namespace tt::hal {
+namespace tt::hal::sdcard {
 
 class SdCard : public Device {
 
@@ -46,7 +46,7 @@ public:
 };
 
 /** Return the SdCard device if the path is within the SdCard mounted path (path std::string::starts_with() check)*/
-std::shared_ptr<SdCard> _Nullable findSdCard(const std::string& path);
+std::shared_ptr<SdCard> _Nullable find(const std::string& path);
 
 /**
  * Acquires an SD card lock if the path is an SD card path.
@@ -54,7 +54,7 @@ std::shared_ptr<SdCard> _Nullable findSdCard(const std::string& path);
  */
 template<typename ReturnType>
 inline ReturnType withSdCardLock(const std::string& path, std::function<ReturnType()> fn) {
-    auto sdcard = hal::findSdCard(path);
+    auto sdcard = find(path);
     std::unique_ptr<ScopedLockableUsage> scoped_lockable;
     if (sdcard != nullptr) {
         scoped_lockable = sdcard->getLockable()->scoped();

--- a/TactilityHeadless/Include/Tactility/hal/sdcard/SdCardDevice.h
+++ b/TactilityHeadless/Include/Tactility/hal/sdcard/SdCardDevice.h
@@ -6,7 +6,7 @@
 
 namespace tt::hal::sdcard {
 
-class SdCard : public Device {
+class SdCardDevice : public Device {
 
 public:
 
@@ -28,8 +28,8 @@ private:
 
 public:
 
-    explicit SdCard(MountBehaviour mountBehaviour) : mountBehaviour(mountBehaviour) {}
-    virtual ~SdCard() override = default;
+    explicit SdCardDevice(MountBehaviour mountBehaviour) : mountBehaviour(mountBehaviour) {}
+    virtual ~SdCardDevice() override = default;
 
     Type getType() const final { return Type::SdCard; };
 
@@ -46,7 +46,7 @@ public:
 };
 
 /** Return the SdCard device if the path is within the SdCard mounted path (path std::string::starts_with() check)*/
-std::shared_ptr<SdCard> _Nullable find(const std::string& path);
+std::shared_ptr<SdCardDevice> _Nullable find(const std::string& path);
 
 /**
  * Acquires an SD card lock if the path is an SD card path.

--- a/TactilityHeadless/Include/Tactility/hal/sdcard/SpiSdCard.h
+++ b/TactilityHeadless/Include/Tactility/hal/sdcard/SpiSdCard.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "Tactility/hal/SdCard.h"
+#include "SdCard.h"
 
 #include <sd_protocol_types.h>
 #include <utility>
@@ -10,13 +10,15 @@
 #include <hal/spi_types.h>
 #include <soc/gpio_num.h>
 
-namespace tt::hal {
+namespace tt::hal::sdcard {
 
 /**
  * SD card interface at the default SPI interface
  */
-class SpiSdCard final : public tt::hal::SdCard {
+class SpiSdCard final : public SdCard {
+
 public:
+
     struct Config {
         Config(
             gpio_num_t spiPinCs,

--- a/TactilityHeadless/Include/Tactility/hal/sdcard/SpiSdCardDevice.h
+++ b/TactilityHeadless/Include/Tactility/hal/sdcard/SpiSdCardDevice.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "SdCard.h"
+#include "SdCardDevice.h"
 
 #include <sd_protocol_types.h>
 #include <utility>
@@ -15,7 +15,7 @@ namespace tt::hal::sdcard {
 /**
  * SD card interface at the default SPI interface
  */
-class SpiSdCard final : public SdCard {
+class SpiSdCardDevice final : public SdCardDevice {
 
 public:
 
@@ -48,7 +48,7 @@ public:
         gpio_num_t spiPinCd; // Card detect
         gpio_num_t spiPinWp; // Write-protect
         gpio_num_t spiPinInt; // Interrupt
-        SdCard::MountBehaviour mountBehaviourAtBoot;
+        SdCardDevice::MountBehaviour mountBehaviourAtBoot;
         std::shared_ptr<Lockable> _Nullable lockable;
         std::vector<gpio_num_t> csPinWorkAround;
         spi_host_device_t spiHost;
@@ -69,8 +69,7 @@ private:
 
 public:
 
-    explicit SpiSdCard(std::unique_ptr<Config> config) :
-        SdCard(config->mountBehaviourAtBoot),
+    explicit SpiSdCardDevice(std::unique_ptr<Config> config) : SdCardDevice(config->mountBehaviourAtBoot),
         config(std::move(config))
     {}
 

--- a/TactilityHeadless/Include/Tactility/hal/touch/Touch.h
+++ b/TactilityHeadless/Include/Tactility/hal/touch/Touch.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "Device.h"
+#include "../Device.h"
 
 #include <lvgl.h>
 
-namespace tt::hal {
+namespace tt::hal::touch {
 
 class Display;
 

--- a/TactilityHeadless/Include/Tactility/hal/touch/TouchDevice.h
+++ b/TactilityHeadless/Include/Tactility/hal/touch/TouchDevice.h
@@ -4,19 +4,18 @@
 
 #include <lvgl.h>
 
-namespace tt::hal::keyboard {
+namespace tt::hal::touch {
 
 class Display;
 
-class Keyboard : public Device {
+class TouchDevice : public Device {
 
 public:
 
-    Type getType() const override { return Type::Keyboard; }
+    Type getType() const override { return Type::SdCard; }
 
     virtual bool start(lv_display_t* display) = 0;
     virtual bool stop() = 0;
-    virtual bool isAttached() const = 0;
 
     virtual lv_indev_t* _Nullable getLvglIndev() = 0;
 };

--- a/TactilityHeadless/Source/hal/Hal.cpp
+++ b/TactilityHeadless/Source/hal/Hal.cpp
@@ -1,7 +1,7 @@
 #include "Tactility/hal/Configuration.h"
 #include "Tactility/hal/Device.h"
 #include "Tactility/hal/i2c/I2c.h"
-#include "Tactility/hal/power/Power.h"
+#include "Tactility/hal/power/PowerDevice.h"
 #include "Tactility/hal/spi/Spi.h"
 #include "Tactility/hal/uart/Uart.h"
 
@@ -42,7 +42,7 @@ void init(const Configuration& configuration) {
     }
 
     if (configuration.power != nullptr) {
-        std::shared_ptr<tt::hal::power::Power> power = configuration.power();
+        std::shared_ptr<tt::hal::power::PowerDevice> power = configuration.power();
         hal::registerDevice(power);
     }
 

--- a/TactilityHeadless/Source/hal/Hal.cpp
+++ b/TactilityHeadless/Source/hal/Hal.cpp
@@ -1,9 +1,9 @@
 #include "Tactility/hal/Configuration.h"
 #include "Tactility/hal/Device.h"
 #include "Tactility/hal/i2c/I2c.h"
+#include "Tactility/hal/power/Power.h"
 #include "Tactility/hal/spi/Spi.h"
 #include "Tactility/hal/uart/Uart.h"
-#include "Tactility/hal/Power.h"
 
 #include <Tactility/kernel/SystemEvents.h>
 
@@ -42,7 +42,7 @@ void init(const Configuration& configuration) {
     }
 
     if (configuration.power != nullptr) {
-        std::shared_ptr<tt::hal::Power> power = configuration.power();
+        std::shared_ptr<tt::hal::power::Power> power = configuration.power();
         hal::registerDevice(power);
     }
 

--- a/TactilityHeadless/Source/hal/sdcard/SdCard.cpp
+++ b/TactilityHeadless/Source/hal/sdcard/SdCard.cpp
@@ -1,9 +1,9 @@
-#include "Tactility/hal/SdCard.h"
+#include "Tactility/hal/sdcard/SdCard.h"
 #include "Tactility/hal/Device.h"
 
-namespace tt::hal {
+namespace tt::hal::sdcard {
 
-std::shared_ptr<SdCard> _Nullable findSdCard(const std::string& path) {
+std::shared_ptr<SdCard> _Nullable find(const std::string& path) {
     auto sdcards = findDevices<SdCard>(Device::Type::SdCard);
     for (auto& sdcard : sdcards) {
         if (sdcard->isMounted() && path.starts_with(sdcard->getMountPath())) {

--- a/TactilityHeadless/Source/hal/sdcard/SdCard.cpp
+++ b/TactilityHeadless/Source/hal/sdcard/SdCard.cpp
@@ -1,10 +1,10 @@
-#include "Tactility/hal/sdcard/SdCard.h"
 #include "Tactility/hal/Device.h"
+#include "Tactility/hal/sdcard/SdCardDevice.h"
 
 namespace tt::hal::sdcard {
 
-std::shared_ptr<SdCard> _Nullable find(const std::string& path) {
-    auto sdcards = findDevices<SdCard>(Device::Type::SdCard);
+std::shared_ptr<SdCardDevice> _Nullable find(const std::string& path) {
+    auto sdcards = findDevices<SdCardDevice>(Device::Type::SdCard);
     for (auto& sdcard : sdcards) {
         if (sdcard->isMounted() && path.starts_with(sdcard->getMountPath())) {
             return sdcard;

--- a/TactilityHeadless/Source/hal/sdcard/SpiSdCard.cpp
+++ b/TactilityHeadless/Source/hal/sdcard/SpiSdCard.cpp
@@ -1,6 +1,6 @@
 #ifdef ESP_PLATFORM
 
-#include "Tactility/hal/sdcard/SpiSdCard.h"
+#include "Tactility/hal/sdcard/SpiSdCardDevice.h"
 
 #include <Tactility/Log.h>
 
@@ -19,7 +19,7 @@ namespace tt::hal::sdcard {
  * See https://github.com/Xinyuan-LilyGO/T-Deck/blob/master/examples/UnitTest/UnitTest.ino
  * @return success result
  */
-bool SpiSdCard::applyGpioWorkAround() {
+bool SpiSdCardDevice::applyGpioWorkAround() {
     TT_LOG_D(TAG, "init");
 
     uint64_t pin_bit_mask = BIT64(config->spiPinCs);
@@ -50,7 +50,7 @@ bool SpiSdCard::applyGpioWorkAround() {
     return true;
 }
 
-bool SpiSdCard::mountInternal(const std::string& newMountPath) {
+bool SpiSdCardDevice::mountInternal(const std::string& newMountPath) {
     TT_LOG_I(TAG, "Mounting %s", newMountPath.c_str());
 
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
@@ -92,7 +92,7 @@ bool SpiSdCard::mountInternal(const std::string& newMountPath) {
     return true;
 }
 
-bool SpiSdCard::mount(const std::string& newMountPath) {
+bool SpiSdCardDevice::mount(const std::string& newMountPath) {
     if (!applyGpioWorkAround()) {
         TT_LOG_E(TAG, "Failed to set SPI CS pins high. This is a pre-requisite for mounting.");
         return false;
@@ -107,7 +107,7 @@ bool SpiSdCard::mount(const std::string& newMountPath) {
     }
 }
 
-bool SpiSdCard::unmount() {
+bool SpiSdCardDevice::unmount() {
     if (card == nullptr) {
         TT_LOG_E(TAG, "Can't unmount: not mounted");
         return false;
@@ -124,7 +124,7 @@ bool SpiSdCard::unmount() {
 }
 
 // TODO: Refactor to "bool getStatus(Status* status)" method so that it can fail when the lvgl lock fails
-SdCard::State SpiSdCard::getState() const {
+SdCardDevice::State SpiSdCardDevice::getState() const {
     if (card == nullptr) {
         return State::Unmounted;
     }

--- a/TactilityHeadless/Source/hal/sdcard/SpiSdCard.cpp
+++ b/TactilityHeadless/Source/hal/sdcard/SpiSdCard.cpp
@@ -1,6 +1,6 @@
 #ifdef ESP_PLATFORM
 
-#include "Tactility/hal/SpiSdCard.h"
+#include "Tactility/hal/sdcard/SpiSdCard.h"
 
 #include <Tactility/Log.h>
 
@@ -10,7 +10,7 @@
 
 #define TAG "spi_sdcard"
 
-namespace tt::hal {
+namespace tt::hal::sdcard {
 
 /**
  * Before we can initialize the sdcard's SPI communications, we have to set all
@@ -124,7 +124,7 @@ bool SpiSdCard::unmount() {
 }
 
 // TODO: Refactor to "bool getStatus(Status* status)" method so that it can fail when the lvgl lock fails
-tt::hal::SdCard::State SpiSdCard::getState() const {
+SdCard::State SpiSdCard::getState() const {
     if (card == nullptr) {
         return State::Unmounted;
     }

--- a/TactilityHeadless/Source/hal/usb/Usb.cpp
+++ b/TactilityHeadless/Source/hal/usb/Usb.cpp
@@ -2,7 +2,7 @@
 
 #include "Tactility/hal/usb/Usb.h"
 #include "Tactility/hal/usb/UsbTusb.h"
-#include "Tactility/hal/SpiSdCard.h"
+#include "Tactility/hal/sdcard/SpiSdCard.h"
 #include "Tactility/TactilityHeadless.h"
 
 #include <Tactility/Log.h>
@@ -32,7 +32,7 @@ sdmmc_card_t* _Nullable getCard() {
         return nullptr;
     }
 
-    auto spi_sdcard = std::static_pointer_cast<SpiSdCard>(sdcard);
+    auto spi_sdcard = std::static_pointer_cast<sdcard::SpiSdCard>(sdcard);
     if (spi_sdcard == nullptr) {
         TT_LOG_W(TAG, "SD card interface is not supported (must be SpiSdCard)");
         return nullptr;

--- a/TactilityHeadless/Source/hal/usb/Usb.cpp
+++ b/TactilityHeadless/Source/hal/usb/Usb.cpp
@@ -1,9 +1,9 @@
 #ifdef ESP_PLATFORM
 
 #include "Tactility/hal/usb/Usb.h"
-#include "Tactility/hal/usb/UsbTusb.h"
-#include "Tactility/hal/sdcard/SpiSdCard.h"
 #include "Tactility/TactilityHeadless.h"
+#include "Tactility/hal/sdcard/SpiSdCardDevice.h"
+#include "Tactility/hal/usb/UsbTusb.h"
 
 #include <Tactility/Log.h>
 
@@ -32,7 +32,7 @@ sdmmc_card_t* _Nullable getCard() {
         return nullptr;
     }
 
-    auto spi_sdcard = std::static_pointer_cast<sdcard::SpiSdCard>(sdcard);
+    auto spi_sdcard = std::static_pointer_cast<sdcard::SpiSdCardDevice>(sdcard);
     if (spi_sdcard == nullptr) {
         TT_LOG_W(TAG, "SD card interface is not supported (must be SpiSdCard)");
         return nullptr;

--- a/TactilityHeadless/Source/service/sdcard/Sdcard.cpp
+++ b/TactilityHeadless/Source/service/sdcard/Sdcard.cpp
@@ -17,7 +17,7 @@ private:
 
     Mutex mutex;
     std::unique_ptr<Timer> updateTimer;
-    hal::SdCard::State lastState = hal::SdCard::State::Unmounted;
+    hal::sdcard::SdCard::State lastState = hal::sdcard::SdCard::State::Unmounted;
 
     bool lock(TickType_t timeout) const {
         return mutex.lock(timeout);
@@ -34,7 +34,7 @@ private:
         if (lock(50)) {
             auto new_state = sdcard->getState();
 
-            if (new_state == hal::SdCard::State::Error) {
+            if (new_state == hal::sdcard::SdCard::State::Error) {
                 TT_LOG_W(TAG, "Sdcard error - unmounting. Did you eject the card in an unsafe manner?");
                 sdcard->unmount();
             }

--- a/TactilityHeadless/Source/service/sdcard/Sdcard.cpp
+++ b/TactilityHeadless/Source/service/sdcard/Sdcard.cpp
@@ -17,7 +17,7 @@ private:
 
     Mutex mutex;
     std::unique_ptr<Timer> updateTimer;
-    hal::sdcard::SdCard::State lastState = hal::sdcard::SdCard::State::Unmounted;
+    hal::sdcard::SdCardDevice::State lastState = hal::sdcard::SdCardDevice::State::Unmounted;
 
     bool lock(TickType_t timeout) const {
         return mutex.lock(timeout);
@@ -34,7 +34,7 @@ private:
         if (lock(50)) {
             auto new_state = sdcard->getState();
 
-            if (new_state == hal::sdcard::SdCard::State::Error) {
+            if (new_state == hal::sdcard::SdCardDevice::State::Error) {
                 TT_LOG_W(TAG, "Sdcard error - unmounting. Did you eject the card in an unsafe manner?");
                 sdcard->unmount();
             }


### PR DESCRIPTION
Implemented more consistent naming:
- Moved all HAL devices into their own namespace (and related folder)
- Post-fixed all HAL device names with "Device"