### PR TITLE
Fix issue with External I2C power on M5Stack Core S3.

### DIFF
--- a/Boards/M5stackCoreS3/Source/InitBoot.cpp
+++ b/Boards/M5stackCoreS3/Source/InitBoot.cpp
@@ -57,6 +57,12 @@ bool initGpioExpander() {
     // Boost enable
     p1_state |= (1U << 7U);
 
+    /* AW9523 P0 is in push-pull mode */
+    if (!aw9523->writeCTL(0x10)) {
+        TT_LOG_E(TAG, "AW9523: Failed to set CTL");
+        return false;
+    }
+
     if (!aw9523->writeP0(p0_state)) {
         TT_LOG_E(TAG, "AW9523: Failed to set P0");
         return false;

--- a/Drivers/AW9523/Source/Aw9523.cpp
+++ b/Drivers/AW9523/Source/Aw9523.cpp
@@ -2,6 +2,7 @@
 
 #define AW9523_REGISTER_P0 0x02
 #define AW9523_REGISTER_P1 0x03
+#define AW9523_REGISTER_CTL 0x11
 
 bool Aw9523::readP0(uint8_t& output) const {
     return readRegister8(AW9523_REGISTER_P0, output);
@@ -11,12 +12,20 @@ bool Aw9523::readP1(uint8_t& output) const {
     return readRegister8(AW9523_REGISTER_P1, output);
 }
 
+bool Aw9523::readCTL(uint8_t& output) const {
+    return readRegister8(AW9523_REGISTER_CTL, output);
+}
+
 bool Aw9523::writeP0(uint8_t value) const {
     return writeRegister8(AW9523_REGISTER_P0, value);
 }
 
 bool Aw9523::writeP1(uint8_t value) const {
     return writeRegister8(AW9523_REGISTER_P1, value);
+}
+
+bool Aw9523::writeCTL(uint8_t value) const {
+    return writeRegister8(AW9523_REGISTER_CTL, value);
 }
 
 bool Aw9523::bitOnP1(uint8_t bitmask) const {

--- a/Drivers/AW9523/Source/Aw9523.h
+++ b/Drivers/AW9523/Source/Aw9523.h
@@ -15,9 +15,11 @@ public:
 
     bool readP0(uint8_t& output) const;
     bool readP1(uint8_t& output) const;
+    bool readCTL(uint8_t& output) const;
 
     bool writeP0(uint8_t value) const;
     bool writeP1(uint8_t value) const;
+    bool writeCTL(uint8_t value) const;
 
     bool bitOnP1(uint8_t bitmask) const;
 };


### PR DESCRIPTION
It's just https://github.com/espressif/esp-bsp/commit/214ce6f191fae75ae4b3872b295eebb58b9fd0a0 adapted to Tactility source code. All credits to original author of fix.

Tested with m5stack cardkb + encoder + joystick connected over hub.