### PR TITLE
SDK fixes

### DIFF
--- a/Buildscripts/release-sdk.sh
+++ b/Buildscripts/release-sdk.sh
@@ -46,4 +46,4 @@ cp Libraries/elf_loader/license.txt $elf_loader_library_path/
 
 cp Buildscripts/CMake/TactilitySDK.cmake $target_path/
 cp Buildscripts/CMake/CMakeLists.txt $target_path/
-echo -n $ESP_IDF_VERSION >> $target_path/idf-version.txt
+printf '%s' "$ESP_IDF_VERSION" >> $target_path/idf-version.txt

--- a/ExternalApps/HelloWorld/build.sh
+++ b/ExternalApps/HelloWorld/build.sh
@@ -1,6 +1,6 @@
 rm sdkconfig
 cp ../../sdkconfig sdkconfig
 cat sdkconfig.override >> sdkconfig
+# First we must run "build" because otherwise "idf.py elf" is not a valid command
 idf.py build
 idf.py elf
-

--- a/ExternalApps/HelloWorld/build.sh
+++ b/ExternalApps/HelloWorld/build.sh
@@ -1,4 +1,6 @@
 rm sdkconfig
 cp ../../sdkconfig sdkconfig
 cat sdkconfig.override >> sdkconfig
-idf.py elf_app
+idf.py build
+idf.py elf
+


### PR DESCRIPTION
- Fix for `ExternalApps/HelloWorld/build.sh`
- Fix portability issue with regards to the SDK release script