### PR TITLE
Merge develop into main

### DIFF
--- a/Boards/CYD-4848S040C/Source/devices/St7701Display.h
+++ b/Boards/CYD-4848S040C/Source/devices/St7701Display.h
@@ -32,4 +32,7 @@ public:
     void setBacklightDuty(uint8_t backlightDuty) override;
 
     bool supportsBacklightDuty() const override { return true; }
+
+    // TODO: Find out why it crashes
+    bool supportsDisplayDriver() const override { return false; }
 };

--- a/Documentation/ideas.md
+++ b/Documentation/ideas.md
@@ -5,14 +5,17 @@
 - Fix Development service: when no SD card is present, the app fails to install. Consider installing to `/data`
   Note: Change app install to "transfer file" functionality. We can have a proper install when we have app packaging.
   Note: Consider installation path option in interface
-- Update ILI934x to v2.0.1
 - External app loading: Check the version of Tactility and check ESP target hardware to check for compatibility.
 - Make a URL handler. Use it for handling local files. Match file types with apps.
   Create some kind of "intent" handler like on Android.
   The intent can have an action (e.g. view), a URL and an optional bundle.
   The manifest can provide the intent handler
-- App packaging
 - Bug: GraphicsDemo should check if display supports the DisplayDriver interface (and same for touch) and show an AlertDialog error if there's a problem
+- Update ILI934x to v2.0.1
+- App packaging
+- Create an "app install paths" settings app to add/remove paths.
+  Scan these paths on startup.
+  Make the AppList use the scan results.
 
 ## Lower Priority
 

--- a/Drivers/EspLcdCompat/Source/EspLcdDisplay.h
+++ b/Drivers/EspLcdCompat/Source/EspLcdDisplay.h
@@ -56,9 +56,10 @@ public:
 
     // endregion
 
-    // region NativeDisplay
+    // region DisplayDriver
 
-    bool supportsDisplayDriver() const override { return true; }
+    // TODO: Find out why it crashes
+    bool supportsDisplayDriver() const override { return false; }
 
     /** @return a NativeDisplay instance if this device supports it */
     std::shared_ptr<tt::hal::display::DisplayDriver> _Nullable getDisplayDriver() final;

--- a/Drivers/EspLcdCompat/Source/EspLcdDisplay.h
+++ b/Drivers/EspLcdCompat/Source/EspLcdDisplay.h
@@ -58,8 +58,7 @@ public:
 
     // region DisplayDriver
 
-    // TODO: Find out why it crashes
-    bool supportsDisplayDriver() const override { return false; }
+    bool supportsDisplayDriver() const override { return true; }
 
     /** @return a NativeDisplay instance if this device supports it */
     std::shared_ptr<tt::hal::display::DisplayDriver> _Nullable getDisplayDriver() final;

--- a/Tactility/Source/service/development/DevelopmentService.cpp
+++ b/Tactility/Source/service/development/DevelopmentService.cpp
@@ -251,7 +251,7 @@ esp_err_t DevelopmentService::handleAppInstall(httpd_req_t* request) {
     content_left -= content_read;
 
     // Write file
-    auto file_path = std::format("/sdcard/{}", filename_entry->second);
+    auto file_path = std::format("/data/{}", filename_entry->second);
     auto* file = fopen(file_path.c_str(), "wb");
     auto file_bytes_written = fwrite(buffer.get(), 1, file_size, file);
     fclose(file);

--- a/TactilityC/Include/tt_app.h
+++ b/TactilityC/Include/tt_app.h
@@ -29,7 +29,7 @@ bool tt_app_has_result(AppHandle handle);
  * @param[out] buffer the output buffer (recommended size is 256 bytes)
  * @param[inout] size used as input for maximum buffer size (including null terminator) and is set with the path string length by this function
  */
-void tt_app_get_data_directory(AppPathsHandle handle, char* buffer, size_t& size);
+void tt_app_get_data_directory(AppPathsHandle handle, char* buffer, size_t* size);
 
 /** Get the path to the data directory of this app, with LVGL drive letter prefix applied.
  * The recommended buffer size is 256 bytes.
@@ -37,7 +37,7 @@ void tt_app_get_data_directory(AppPathsHandle handle, char* buffer, size_t& size
  * @param[out] buffer the output buffer (recommended size is 256 bytes)
  * @param[inout] size used as input for maximum buffer size (including null terminator) and is set with the path string length by this function
  */
-void tt_app_get_data_directory_lvgl(AppPathsHandle handle, char* buffer, size_t& size);
+void tt_app_get_data_directory_lvgl(AppPathsHandle handle, char* buffer, size_t* size);
 
 /**
  * Start an app by id.

--- a/TactilityC/Include/tt_kernel.h
+++ b/TactilityC/Include/tt_kernel.h
@@ -8,6 +8,8 @@ extern "C" {
 
 typedef unsigned long TickType;
 
+#define MAX_TICKS INT32_MAX
+
 /**
  * Stall the current task for the specified amount of time.
  * @param milliseconds the time in milliseconds to stall.

--- a/TactilityC/Source/tt_app.cpp
+++ b/TactilityC/Source/tt_app.cpp
@@ -33,38 +33,40 @@ void tt_app_stop() {
     tt::app::stop();
 }
 
-void tt_app_get_data_directory(AppPathsHandle handle, char* buffer, size_t& size) {
+void tt_app_get_data_directory(AppPathsHandle handle, char* buffer, size_t* size) {
     assert(buffer != nullptr);
-    assert(size > 0);
+    assert(size != nullptr);
+    assert(*size > 0);
     auto paths = HANDLE_AS_APP_CONTEXT(handle)->getPaths();
     auto data_path = paths->getDataDirectory();
     auto expected_length = data_path.length() + 1;
-    if (size < expected_length) {
+    if (*size < expected_length) {
         TT_LOG_E(TAG, "Path buffer not large enough (%d < %d)", size, expected_length);
-        size = 0;
+        *size = 0;
         buffer[0] = 0;
         return;
     }
 
     strcpy(buffer, data_path.c_str());
-    size = data_path.length();
+    *size = data_path.length();
 }
 
-void tt_app_get_data_directory_lvgl(AppPathsHandle handle, char* buffer, size_t& size) {
+void tt_app_get_data_directory_lvgl(AppPathsHandle handle, char* buffer, size_t* size) {
     assert(buffer != nullptr);
-    assert(size > 0);
+    assert(size != nullptr);
+    assert(*size > 0);
     auto paths = HANDLE_AS_APP_CONTEXT(handle)->getPaths();
     auto data_path = paths->getDataDirectoryLvgl();
     auto expected_length = data_path.length() + 1;
-    if (size < expected_length) {
+    if (*size < expected_length) {
         TT_LOG_E(TAG, "Path buffer not large enough (%d < %d)", size, expected_length);
-        size = 0;
+        *size = 0;
         buffer[0] = 0;
         return;
     }
 
     strcpy(buffer, data_path.c_str());
-    size = data_path.length();
+    *size = data_path.length();
 }
 
 }

--- a/TactilityC/Source/tt_init.cpp
+++ b/TactilityC/Source/tt_init.cpp
@@ -105,6 +105,7 @@ const esp_elfsym elf_symbols[] {
     ESP_ELFSYM_EXPORT(tolower),
     ESP_ELFSYM_EXPORT(toupper),
     // ESP-IDF
+    ESP_ELFSYM_EXPORT(esp_log),
     ESP_ELFSYM_EXPORT(esp_log_write),
     ESP_ELFSYM_EXPORT(esp_log_timestamp),
     // Tactility


### PR DESCRIPTION
- Disable `DisplayDriver` for `St7701Display` (on CYD 4848)
- Improve `GraphicsDemo`: check for feature capability and show alert dialog if there's an issue
- `DevelopmentService` installs to `/data` instead of `/sdcard`
- Fixed `tt_app_get_data_directory()` and `tt_app_get_data_directory_lvgl()` (C++ to C)
- `tt_kernel.h` now defines `MAX_TICKS`
- `tt_init.cpp` now exports `esp_log()` which is required since ESP-IDF 5.5