### PR TITLE
Fix bug and update external app sdk versions

### DIFF
--- a/Documentation/ideas.md
+++ b/Documentation/ideas.md
@@ -16,7 +16,8 @@
 - Create an "app install paths" settings app to add/remove paths.
   Scan these paths on startup.
   Make the AppList use the scan results.
-
+- Apps with update timer should check `lvgl::isStarted()`
+ 
 ## Medium Priority
 
 - Unify the way displays are dimmed. Some implementations turn off the display when it's fully dimmed. Make this a separate functionality.

--- a/ExternalApps/Calculator/tactility.properties
+++ b/ExternalApps/Calculator/tactility.properties
@@ -1,2 +1,2 @@
 [sdk]
-version = 0.4.0
+version = 0.5.0-SNAPSHOT

--- a/ExternalApps/GraphicsDemo/tactility.properties
+++ b/ExternalApps/GraphicsDemo/tactility.properties
@@ -1,2 +1,2 @@
 [sdk]
-version = 0.4.0
+version = 0.5.0-SNAPSHOT

--- a/ExternalApps/HelloWorld/tactility.properties
+++ b/ExternalApps/HelloWorld/tactility.properties
@@ -1,2 +1,2 @@
 [sdk]
-version = 0.4.0
+version = 0.5.0-SNAPSHOT

--- a/Tactility/Source/app/development/Development.cpp
+++ b/Tactility/Source/app/development/Development.cpp
@@ -1,5 +1,7 @@
 #ifdef ESP_PLATFORM
 
+#include "Tactility/lvgl/Lvgl.h"
+
 #include <Tactility/Tactility.h>
 
 #include <Tactility/app/AppManifest.h>
@@ -28,7 +30,7 @@ class DevelopmentApp final : public App {
 
     Timer timer = Timer(Timer::Type::Periodic, [this] {
         auto lock = lvgl::getSyncLock()->asScopedLock();
-        if (lock.lock(lvgl::defaultLockTime)) {
+        if (lock.lock(lvgl::defaultLockTime) && lvgl::isStarted()) {
             updateViewState();
         }
     });


### PR DESCRIPTION
- Fix bug in Development app: when launching/stopping external app due to LVGL being stopped and a timer still being active (sometimes, as it's a race condition)
- Added TODO to fix the same bug in other apps
- Update external app SDKs to `0.5.0-SNAPSHOT`