### PR TITLE
Fix for I2C Scanner crash and updated CYD-2432S028R board

### DIFF
--- a/Boards/CYD-2432S028R/Source/CYD2432S028R.cpp
+++ b/Boards/CYD-2432S028R/Source/CYD2432S028R.cpp
@@ -36,9 +36,27 @@ static DeviceVector createDevices() {
 const Configuration cyd_2432s028r_config = {
     .initBoot = initBoot,
     .createDevices = createDevices,
-    .i2c = {},
+    .i2c = {
+        i2c::Configuration {
+            .name = "CN1",
+            .port = I2C_NUM_0,
+            .initMode = i2c::InitMode::ByTactility,
+            .isMutable = true,
+            .config = (i2c_config_t) {
+                .mode = I2C_MODE_MASTER,
+                .sda_io_num = GPIO_NUM_27,
+                .scl_io_num = GPIO_NUM_22,
+                .sda_pullup_en = false,
+                .scl_pullup_en = false,
+                .master = {
+                    .clk_speed = 400000
+                },
+                .clk_flags = 0
+            }
+        }
+    },
     .spi {
-        //Display
+        // Display
         spi::Configuration {
             .device = SPI2_HOST,
             .dma = SPI_DMA_CH_AUTO,
@@ -62,7 +80,6 @@ const Configuration cyd_2432s028r_config = {
             .isMutable = false,
             .lock = tt::lvgl::getSyncLock()
         },
-        
         // SDCard
         spi::Configuration {
             .device = SPI3_HOST,
@@ -87,5 +104,31 @@ const Configuration cyd_2432s028r_config = {
             .isMutable = false,
             .lock = tt::lvgl::getSyncLock() // esp_lvgl_port owns the lock for the display
         },
+    },
+
+    .uart {
+        uart::Configuration {
+            .name = "P1",
+            .port = UART_NUM_1,
+            .rxPin = GPIO_NUM_1,
+            .txPin = GPIO_NUM_3,
+            .rtsPin = GPIO_NUM_NC,
+            .ctsPin = GPIO_NUM_NC,
+            .rxBufferSize = 1024,
+            .txBufferSize = 1024,
+            .config = {
+                .baud_rate = 115200,
+                .data_bits = UART_DATA_8_BITS,
+                .parity    = UART_PARITY_DISABLE,
+                .stop_bits = UART_STOP_BITS_1,
+                .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+                .rx_flow_ctrl_thresh = 0,
+                .source_clk = UART_SCLK_DEFAULT,
+                .flags = {
+                    .allow_pd = 0,
+                    .backup_before_sleep = 0,
+                }
+            }
+        }
     }
 };

--- a/Tactility/Source/app/i2cscanner/I2cScanner.cpp
+++ b/Tactility/Source/app/i2cscanner/I2cScanner.cpp
@@ -138,12 +138,12 @@ void I2cScannerApp::onShow(AppContext& app, lv_obj_t* parent) {
     lv_obj_add_flag(scan_list, LV_OBJ_FLAG_HIDDEN);
     scanListWidget = scan_list;
 
-    auto i2c_devices = tt::getConfiguration()->hardware->i2c;
-    if (selected_bus )
-    assert(selected_bus < i2c_devices.size());
-    port = i2c_devices[selected_bus].port;
-
-    selectBus(selected_bus);
+    auto i2c_devices = getConfiguration()->hardware->i2c;
+    if (!i2c_devices.empty()) {
+        assert(selected_bus < i2c_devices.size());
+        port = i2c_devices[selected_bus].port;
+        selectBus(selected_bus);
+    }
 }
 
 void I2cScannerApp::onHide(AppContext& app) {
@@ -311,7 +311,7 @@ void I2cScannerApp::onSelectBus(lv_event_t* event) {
 }
 
 void I2cScannerApp::selectBus(int32_t selected) {
-    auto i2c_devices = tt::getConfiguration()->hardware->i2c;
+    auto i2c_devices = getConfiguration()->hardware->i2c;
     assert(selected < i2c_devices.size());
 
     if (mutex.lock(100 / portTICK_PERIOD_MS)) {
@@ -322,7 +322,7 @@ void I2cScannerApp::selectBus(int32_t selected) {
     }
 
     TT_LOG_I(TAG, "Selected %ld", selected);
-    setLastBusIndex((int32_t)selected);
+    setLastBusIndex(selected);
 
     startScanning();
 


### PR DESCRIPTION
- Fix for crash when I2C Scanner is started and no I2C devices were found in the board configuration
- Add I2C and UART configurations to CYD-2432S028R board