### PR TITLE
[SystemSettings] Switch to relative file path

### DIFF
--- a/Tactility/Source/settings/SystemSettings.cpp
+++ b/Tactility/Source/settings/SystemSettings.cpp
@@ -7,7 +7,7 @@
 namespace tt::settings {
 
 constexpr auto* TAG = "SystemSettings";
-constexpr auto* FILE_PATH = "/data/settings/system.properties";
+constexpr auto* FILE_PATH = "./data/settings/system.properties";
 
 static Mutex mutex = Mutex();
 static bool cached = false;


### PR DESCRIPTION
Fixes simulator error (Failed to load system.properties settings file) if the path is absolute