### PR TITLE
added support for 1-line bus width sdmmc device mode

### DIFF
--- a/Tactility/Include/Tactility/hal/sdcard/SdmmcDevice.h
+++ b/Tactility/Include/Tactility/hal/sdcard/SdmmcDevice.h
@@ -31,7 +31,8 @@ public:
             gpio_num_t pinD1,
             gpio_num_t pinD2,
             gpio_num_t pinD3,
-            MountBehaviour mountBehaviourAtBoot
+            MountBehaviour mountBehaviourAtBoot,
+            uint8_t busWidth = 4
         ) :
             pinClock(pinClock),
             pinCmd(pinCmd),
@@ -39,7 +40,8 @@ public:
             pinD1(pinD1),
             pinD2(pinD2),
             pinD3(pinD3),
-            mountBehaviourAtBoot(mountBehaviourAtBoot)
+            mountBehaviourAtBoot(mountBehaviourAtBoot),
+            busWidth(busWidth)
         {}
 
         int spiFrequencyKhz;
@@ -50,6 +52,7 @@ public:
         gpio_num_t pinD2;
         gpio_num_t pinD3;
         MountBehaviour mountBehaviourAtBoot;
+        uint8_t busWidth;
         bool formatOnMountFailed = false;
         uint16_t maxOpenFiles = 4;
         uint16_t allocUnitSize = 16 * 1024;

--- a/Tactility/Source/hal/sdcard/SdmmcDevice.cpp
+++ b/Tactility/Source/hal/sdcard/SdmmcDevice.cpp
@@ -41,7 +41,7 @@ bool SdmmcDevice::mountInternal(const std::string& newMountPath) {
         .d7  = static_cast<gpio_num_t>(0),
         .cd  = GPIO_NUM_NC,
         .wp  = GPIO_NUM_NC,
-        .width = 4,
+        .width = config->busWidth,
         .flags = 0
       };
 


### PR DESCRIPTION
This MR adds support for 1-line bus width mode in the SDMMC driver to accommodate boards with limited pin availability, while maintaining the 4-line mode as the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SD/MMC device bus width is now configurable via configuration settings (default: 4-bit mode), replacing the previously fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->