### PR TITLE
Revert LVGL from 9.4.0 to 9.3.0

### DIFF
--- a/Documentation/ideas.md
+++ b/Documentation/ideas.md
@@ -44,6 +44,7 @@
 - Support direct installation of an `.app` file with `tactility.py install helloworld.app <ip>`
 - Support `tactility.py target <ip>` to remember the device IP address.
 - minitar/untarFile(): "entry->metadata.path" can escape its confined path (e.g. "../something")
+- Refactor elf loader code to make it multi-platform and to support multiple types of executables
 
 ## Medium Priority
 
@@ -61,13 +62,10 @@
 - Bug: Turn on WiFi (when testing it wasn't connected/connecting - just active). Open chat. Observe crash.
 - Bug: Crash handling app cannot be exited with an EncoderDevice. (current work-around is to manually reset the device)
 - I2C app should show error when I2C port is disabled when the scan button was manually pressed
-- TactilitySDK: Support automatic scanning of header files so that we can generate the `tt_init.cpp` symbols list.
-- elf_loader: split up symbol lists further (after radio support is implemented)
 
 ## Lower Priority
 
 - Rename `Lock::lock()` and `Lock::unlock()` to `Lock::acquire()` and `Lock::release()`?
-- elf_loader: make main() entry-point optional (so we can build libraries, or have the `manifest` as a global symbol)
 - Implement system suspend that turns off the screen
 - The boot button on some devices can be used as GPIO_NUM_0 at runtime
 - Localize all apps

--- a/Firmware/idf_component.yml
+++ b/Firmware/idf_component.yml
@@ -55,7 +55,7 @@ dependencies:
     rules:
       - if: "target == esp32s3"
   espressif/esp_lvgl_port: "2.7.0"
-  lvgl/lvgl: "9.4.0"
+  lvgl/lvgl: "9.3.0"
   FastEPD:
     git: https://github.com/bitbank2/FastEPD.git
     version: 1.4.2


### PR DESCRIPTION
LVGL 9.4.0 had intermittend stability issues on T-Deck:
Sometimes the device would simply refuse to boot and show a black screen. It would fail during init and it related to touch or the display.

One way to consistently reproduce it was to enable Wi-Fi, enable development settings, then reboot into USB Mass Storage for SD card.

We'll keep LVGL 9.4.0 for the simullator for now.