### PR TITLE
Add merged binaries to release assets

### DIFF
--- a/.github/actions/build-firmware/action.yml
+++ b/.github/actions/build-firmware/action.yml
@@ -29,6 +29,7 @@ runs:
     - name: 'Merge binary'
       shell: bash
       run: |
+        python -m pip install esptool
         cd release/Tactility-${{ inputs.board_id }}
         bash ./merge.sh ${{ inputs.arch }}
         mv Binaries/merged_binary.bin ../Tactility-${{ inputs.board_id }}.bin

--- a/.github/actions/build-firmware/action.yml
+++ b/.github/actions/build-firmware/action.yml
@@ -26,6 +26,12 @@ runs:
     - name: 'Release'
       shell: bash
       run: Buildscripts/release.sh ${{ inputs.board_id }}
+    - name: 'Merge binary'
+      shell: bash
+      run: |
+        cd release/Tactility-${{ inputs.board_id }}
+        bash ./merge.sh ${{ inputs.arch }}
+        mv Binaries/merged_binary.bin ../Tactility-${{ inputs.board_id }}.bin
     - name: 'Upload Artifact: Release'
       uses: actions/upload-artifact@v4
       with:
@@ -37,4 +43,10 @@ runs:
       with:
         name: Tactility-${{ inputs.board_id }}-symbols
         path: release/Tactility-${{ inputs.board_id }}-symbols
+        retention-days: 30
+    - name: 'Upload Artifact: Merged binary'
+      uses: actions/upload-artifact@v4
+      with:
+        name: Tactility-${{ inputs.board_id }}.bin
+        path: release/Tactility-${{ inputs.board_id }}.bin
         retention-days: 30

--- a/Buildscripts/CDN/generate-firmware-files.py
+++ b/Buildscripts/CDN/generate-firmware-files.py
@@ -191,7 +191,7 @@ def main(in_path: str, out_path: str, version: str):
         devices=[]
     )
     for artifact_directory in artifact_directories:
-        if artifact_directory.endswith("-symbols") or artifact_directory.startswith("TactilitySDK-"):
+        if artifact_directory.endswith("-symbols") or artifact_directory.endswith(".bin") or artifact_directory.startswith("TactilitySDK-"):
             continue
         device_id = artifact_directory.removeprefix("Tactility-")
         if not device_id:

--- a/Buildscripts/Flashing/merge.ps1
+++ b/Buildscripts/Flashing/merge.ps1
@@ -1,0 +1,20 @@
+param(
+    $port
+)
+
+if ((Get-Command "esptool" -ErrorAction SilentlyContinue) -eq $null)
+{
+    Write-Host "Unable to find esptool in your path. Make sure you have Python installed and on your path. Then run `pip install esptool`."
+}
+
+# Create merge command based on partitions
+$json = Get-Content .\Binaries\flasher_args.json -Raw | ConvertFrom-Json
+$jsonClean = $json.flash_files -replace '[\{\}\@\;]', ''
+$jsonClean = $jsonClean -replace '[\=]', ' '
+
+cd Binaries
+# "--chip esp32s3" is irrelevant, just need to be added, works for all variant
+$command = "esptool --chip esp32s3 merge-bin --output merged_binary.bin $jsonClean"
+Invoke-Expression $command
+cd ..
+

--- a/Buildscripts/Flashing/merge.ps1
+++ b/Buildscripts/Flashing/merge.ps1
@@ -1,10 +1,12 @@
 param(
-    $port
+    # "--chip esp32s3" is irrelevant, just need to be added, fallback to "esp32s3"
+    [string]$chip = "esp32s3"
 )
 
-if ((Get-Command "esptool" -ErrorAction SilentlyContinue) -eq $null)
+if ($null -eq (Get-Command "esptool" -ErrorAction SilentlyContinue))
 {
     Write-Host "Unable to find esptool in your path. Make sure you have Python installed and on your path. Then run `pip install esptool`."
+    exit 1
 }
 
 # Create merge command based on partitions
@@ -12,9 +14,13 @@ $json = Get-Content .\Binaries\flasher_args.json -Raw | ConvertFrom-Json
 $jsonClean = $json.flash_files -replace '[\{\}\@\;]', ''
 $jsonClean = $jsonClean -replace '[\=]', ' '
 
-cd Binaries
-# "--chip esp32s3" is irrelevant, just need to be added, works for all variant
-$command = "esptool --chip esp32s3 merge-bin --output merged_binary.bin $jsonClean"
-Invoke-Expression $command
-cd ..
+$mergeArgs = @('--chip', $chip, 'merge-bin', '--output', 'merged_binary.bin') + ($jsonClean -split '\s+' | Where-Object { $_ })
+Push-Location Binaries
+& esptool @mergeArgs
+$exitCode = $LASTEXITCODE
+Pop-Location
+
+if ($exitCode -ne 0) {
+    exit $exitCode
+}
 

--- a/Buildscripts/Flashing/merge.sh
+++ b/Buildscripts/Flashing/merge.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Usage:
+#   merge.sh [chip]
+#
+# Arguments:
+#   chip - optional ESP32 SOC variant (e.g. esp32, esp32s3, esp32c6)
+#
+# Requirements:
+#   jq - run 'pip install jq'
+#   esptool.py - run 'pip install esptool'
+#
+# Documentation:
+#   https://docs.espressif.com/projects/esptool/en/latest/esp32/
+#
+
+# Source: https://stackoverflow.com/a/53798785
+function is_bin_in_path {
+  builtin type -P "$1" &> /dev/null
+}
+
+function require_bin {
+  program=$1
+  if ! is_bin_in_path $program; then
+      exit 1
+  else
+      exit 0
+  fi
+}
+
+# Find either esptool (installed via system package manager) or esptool.py (installed via pip)
+if ! is_bin_in_path esptool; then
+  if ! is_bin_in_path esptool.py; then
+    echo "\e[31m⚠️  esptool not found! Install it from your package manager or install python and run 'pip install esptool'\e[0m"
+    exit 1
+  else 
+    esptoolPath=esptool.py
+  fi
+else
+  esptoolPath=esptool
+fi
+
+chip=${1:-esp32s3}
+
+# Take the flash_arg file contents and join each line in the file into a single line
+flash_args=`tr '\n' ' ' < Binaries/flash_args`
+cd Binaries
+$esptoolPath --chip "$chip" merge-bin --output merged_binary.bin $flash_args
+cd -
+

--- a/Buildscripts/Flashing/merge.sh
+++ b/Buildscripts/Flashing/merge.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Usage:
 #   merge.sh [chip]
@@ -43,8 +43,10 @@ fi
 chip=${1:-esp32s3}
 
 # Take the flash_arg file contents and join each line in the file into a single line
-flash_args=`tr '\n' ' ' < Binaries/flash_args`
-cd Binaries
-$esptoolPath --chip "$chip" merge-bin --output merged_binary.bin $flash_args
-cd -
+flash_args="$(tr '\n' ' ' < Binaries/flash_args)"
+read -r -a flash_args_array <<< "$flash_args"
+(
+  cd Binaries || exit 1
+  "$esptoolPath" --chip "$chip" merge-bin --output merged_binary.bin "${flash_args_array[@]}"
+) || exit 1
 


### PR DESCRIPTION
## Summary

This PR adds merged firmware binaries to the firmware build artifacts.

Each firmware build now produces three artifacts per environment/device:

- `Tactility-<board>.zip`
- `Tactility-<board>-symbols.zip`
- `Tactility-<board>.bin`

The `.bin` file is generated from the release binaries using the new merge script and is named after the same environment/device as the regular release artifact.

## Changes

- Added `Buildscripts/Flashing/merge.sh` and `Buildscripts/Flashing/merge.ps1` to the release package.
- Updated the firmware build workflow to install `esptool` and run `merge.sh` after creating the release folder.
- The workflow now uploads `Tactility-<board>.bin` as an additional artifact.
- `merge.sh` accepts an optional chip argument and falls back to `esp32s3` when not provided.
- The workflow passes the board architecture to `merge.sh`, so merged binaries are generated with the correct ESP target.
- Updated CDN firmware generation to ignore `.bin` artifacts so they are not treated as firmware package directories.

## Notes

The merged binary is generated as `merged_binary.bin` by `esptool merge-bin`, then renamed to `Tactility-<board>.bin` before being uploaded as an artifact.

## Tests

Tested CI, but couldn't test release assets due to secrets used by CDN, but merged binary artifact is being passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Release builds now produce a single merged firmware binary and upload it as part of the release artifacts (30-day retention).

* **Chores**
  - Added cross-platform binary merge tooling to the build pipeline.
  - Improved CDN/manifest generation to ignore intermediate binary directories during artifact indexing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TactilityProject/Tactility/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->