### PR TITLE
Fix for CoreS3 touch

### DIFF
--- a/Devices/m5stack-cores3/CMakeLists.txt
+++ b/Devices/m5stack-cores3/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SOURCE_FILES Source/*.c*)
 idf_component_register(
     SRCS ${SOURCE_FILES}
     INCLUDE_DIRS "Source"
-    REQUIRES Tactility esp_lvgl_port ILI934x FT6x36 AXP2101 AW9523 driver vfs fatfs
+    REQUIRES Tactility esp_lvgl_port ILI934x FT5x06 AXP2101 AW9523 driver vfs fatfs
 )

--- a/Devices/m5stack-cores3/Source/devices/Display.cpp
+++ b/Devices/m5stack-cores3/Source/devices/Display.cpp
@@ -1,7 +1,7 @@
 #include "Display.h"
 
 #include <Axp2101.h>
-#include <Ft6x36Touch.h>
+#include <Ft5x06Touch.h>
 #include <Ili934xDisplay.h>
 #include <Tactility/Logger.h>
 #include <Tactility/hal/i2c/I2c.h>
@@ -17,16 +17,13 @@ static void setBacklightDuty(uint8_t backlightDuty) {
 }
 
 static std::shared_ptr<tt::hal::touch::TouchDevice> createTouch() {
-    auto configuration = std::make_unique<Ft6x36Touch::Configuration>(
+    auto configuration = std::make_unique<Ft5x06Touch::Configuration>(
         I2C_NUM_0,
         319,//LCD_HORIZONTAL_RESOLUTION,
-        239,//LCD_VERTICAL_RESOLUTION,
-        false,
-        false,
-        false
+        239//LCD_VERTICAL_RESOLUTION,
     );
 
-    return std::make_shared<Ft6x36Touch>(std::move(configuration));
+    return std::make_shared<Ft5x06Touch>(std::move(configuration));
 }
 
 std::shared_ptr<tt::hal::display::DisplayDevice> createDisplay() {


### PR DESCRIPTION
The FT6 driver does a hardware ID check, which fails on the CoreS3 but not on Stackchan for some reason. FT5 works on Stackchan, so we'll use that for all devices, just like M5GFX does.

This is a partial revert of changes from https://github.com/TactilityProject/Tactility/pull/526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated touch driver for improved M5Stack CoreS3 device compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->