### PR TITLE
tab5 tinyusb msc

### DIFF
--- a/Devices/m5stack-tab5/Source/devices/Tab5Keyboard.cpp
+++ b/Devices/m5stack-tab5/Source/devices/Tab5Keyboard.cpp
@@ -151,7 +151,7 @@ bool Tab5Keyboard::writeReg(uint8_t reg, uint8_t value) const {
 }
 
 // ---------------------------------------------------------------------------
-// LED helpers - LED0 = Sym indicator (green), LED1 = Aa indicator (amber)
+// LED helpers - LED0 = Sym indicator (green), LED1 = Aa indicator (red)
 // RGB register layout: [B, G, R] per LED, stride 4 (byte 3 reserved)
 // ---------------------------------------------------------------------------
 void Tab5Keyboard::updateLeds() {

--- a/Devices/m5stack-tab5/device.properties
+++ b/Devices/m5stack-tab5/device.properties
@@ -14,6 +14,7 @@ spiRamSpeed=200M
 esptoolFlashFreq=80M
 bluetooth=true
 usbHostEnabled=true
+tinyUsb=true
 
 [display]
 size=5"

--- a/Firmware/idf_component.yml
+++ b/Firmware/idf_component.yml
@@ -64,7 +64,7 @@ dependencies:
   espressif/esp_tinyusb:
     version: "1.7.6~1"
     rules:
-      - if: "target == esp32s3"
+      - if: "target in [esp32s3, esp32p4]"
   espressif/esp_lvgl_port: "2.7.2"
   lvgl/lvgl: "9.3.0"
   epdiy:

--- a/Tactility/CMakeLists.txt
+++ b/Tactility/CMakeLists.txt
@@ -35,7 +35,7 @@ if (DEFINED ENV{ESP_IDF_VERSION})
         spi_flash
     )
 
-    if ("${IDF_TARGET}" STREQUAL "esp32s3")
+    if ("${IDF_TARGET}" STREQUAL "esp32s3" OR "${IDF_TARGET}" STREQUAL "esp32p4")
         list(APPEND REQUIRES_LIST esp_tinyusb)
     endif ()
 

--- a/Tactility/Source/hal/usb/UsbTusb.cpp
+++ b/Tactility/Source/hal/usb/UsbTusb.cpp
@@ -12,6 +12,10 @@
 #include <tusb_msc_storage.h>
 #include <wear_levelling.h>
 
+#if CONFIG_IDF_TARGET_ESP32P4
+#include "hal/usb_wrap_ll.h"
+#endif
+
 #define EPNUM_MSC 1
 #define TUSB_DESC_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_MSC_DESC_LEN)
 #define SECTOR_SIZE 512
@@ -104,6 +108,13 @@ static bool ensureDriverInstalled() {
     if (driverInstalled) {
         return true;
     }
+
+#if CONFIG_IDF_TARGET_ESP32P4
+    // Tab5's USB-C port is wired to FSLS PHY0, but the USB_WRAP (FS/FSLS) controller
+    // used by TinyUSB device mode defaults to FSLS PHY1. Route it to PHY0 before
+    // installing the TinyUSB driver.
+    usb_wrap_ll_phy_select(&USB_WRAP, 0);
+#endif
 
     const tinyusb_config_t tusb_cfg = {
         .device_descriptor = &descriptor_config,
@@ -198,6 +209,9 @@ bool tusbStartMassStorageWithFlash() {
 
 void tusbStop() {
     tinyusb_msc_storage_deinit();
+#if CONFIG_IDF_TARGET_ESP32P4
+    usb_wrap_ll_phy_select(&USB_WRAP, 1);
+#endif
 }
 
 bool tusbCanStartMassStorageWithFlash() {

--- a/Tactility/Source/hal/usb/UsbTusb.cpp
+++ b/Tactility/Source/hal/usb/UsbTusb.cpp
@@ -134,6 +134,10 @@ static bool ensureDriverInstalled() {
 
     if (tinyusb_driver_install(&tusb_cfg) != ESP_OK) {
         LOGGER.error("Failed to install TinyUSB driver");
+#if CONFIG_IDF_TARGET_ESP32P4
+        // Roll back routing when TinyUSB did not start.
+        usb_wrap_ll_phy_select(&USB_WRAP, 1);
+#endif
         return false;
     }
 

--- a/device.py
+++ b/device.py
@@ -316,6 +316,13 @@ def write_usb_variables(output_file, device_properties: ConfigParser):
         output_file.write("# TinyUSB\n")
         output_file.write("CONFIG_TINYUSB_MSC_ENABLED=y\n")
         output_file.write("CONFIG_TINYUSB_MSC_MOUNT_PATH=\"/sdcard\"\n")
+        idf_target = get_property_or_exit(device_properties, "hardware", "target").lower()
+        if idf_target == "esp32p4":
+            # P4 has two USB-DWC controllers (HS/UTMI and FS/FSLS). esp_tinyusb defaults to
+            # RHPORT_HS (UTMI), which is the same controller claimed by usbhost0's
+            # peripheral-map=<0> (USB-A). Force RHPORT_FS so TinyUSB device mode binds to
+            # the FS/FSLS controller (USB-C OTG on Tab5), avoiding the conflict.
+            output_file.write("CONFIG_TINYUSB_RHPORT_FS=y\n")
 
 def write_bluetooth_variables(output_file, device_properties: ConfigParser):
     idf_target = get_property_or_exit(device_properties, "hardware", "target").lower()


### PR DESCRIPTION
Tab5 tinyusb msc support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled TinyUSB support for M5Stack Tab5, adding USB device capabilities.
  * Extended TinyUSB compatibility and improved USB behavior on ESP32P4 targets.

* **Documentation**
  * Corrected Tab5 keyboard LED reference: LED1 is red (previously described as amber).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->