### PR TITLE
Fix for Gt911Touch when using new I2C driver

### DIFF
--- a/Drivers/GT911/Source/Gt911Touch.cpp
+++ b/Drivers/GT911/Source/Gt911Touch.cpp
@@ -22,6 +22,7 @@ bool Gt911Touch::createIoHandle(esp_lcd_panel_io_handle_t& outHandle) {
         io_config.dev_addr = ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS;
     } else if (i2c_controller_has_device_at_address(i2c, ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP, pdMS_TO_TICKS(10)) == ERROR_NONE) {
         io_config.dev_addr = ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP;
+        io_config.scl_speed_hz = esp32_i2c_master_get_clock_frequency(configuration->i2cController);
     } else {
         LOGGER.error("No device found on I2C bus");
         return false;


### PR DESCRIPTION
Committing this straight to main branch to avoid wasting pipelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GT911 touch driver initialization process by correcting how hardware configuration settings are retrieved and applied. Previously using default settings, the driver now properly utilizes device-specific hardware configuration. This ensures proper touch controller functionality across different device configurations and may enhance touch input responsiveness and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->