### PR TITLE
Add XL9555 I/O expander kernel module

### DIFF
--- a/Buildscripts/TactilitySDK/TactilitySDK.cmake
+++ b/Buildscripts/TactilitySDK/TactilitySDK.cmake
@@ -31,6 +31,7 @@ macro(tactility_project project_name)
         pi4ioe5v6408-module
         qmi8658-module
         rx8130ce-module
+        xl9555-module
     )
 
 endmacro()

--- a/Drivers/xl9555-module/CMakeLists.txt
+++ b/Drivers/xl9555-module/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../Buildscripts/module.cmake")
+
+file(GLOB_RECURSE SOURCE_FILES "source/*.c*")
+
+tactility_add_module(xl9555-module
+    SRCS ${SOURCE_FILES}
+    INCLUDE_DIRS include/
+    REQUIRES TactilityKernel
+)

--- a/Drivers/xl9555-module/LICENSE-Apache-2.0.md
+++ b/Drivers/xl9555-module/LICENSE-Apache-2.0.md
@@ -1,0 +1,195 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+* **(b)** You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+

--- a/Drivers/xl9555-module/README.md
+++ b/Drivers/xl9555-module/README.md
@@ -1,0 +1,11 @@
+# XL9555 I/O expander
+
+A driver for the `XL9555` 16-bit I2C-bus I/O expander, used by several LilyGO boards
+(e.g. T-Deck Pro Max) for power-rail enables, reset lines, and antenna/audio routing.
+Its register map is PCA9555-compatible: two 8-bit ports for input, output, polarity
+inversion, and direction, addressed as pins 0-15 (port 0 = pins 0-7, port 1 = pins 8-15).
+
+It does not support pull-up/down resistors or high-impedance outputs; requesting those
+flags returns `ERROR_NOT_SUPPORTED`.
+
+License: [Apache v2.0](LICENSE-Apache-2.0.md)

--- a/Drivers/xl9555-module/bindings/xlsemi,xl9555.yaml
+++ b/Drivers/xl9555-module/bindings/xlsemi,xl9555.yaml
@@ -1,0 +1,5 @@
+description: XLSEMI XL9555 16-bit I2C-bus I/O expander (PCA9555-register-compatible)
+
+include: ["i2c-device.yaml"]
+
+compatible: "xlsemi,xl9555"

--- a/Drivers/xl9555-module/devicetree.yaml
+++ b/Drivers/xl9555-module/devicetree.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - TactilityKernel
+bindings: bindings

--- a/Drivers/xl9555-module/include/bindings/xl9555.h
+++ b/Drivers/xl9555-module/include/bindings/xl9555.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tactility/bindings/bindings.h>
+#include <drivers/xl9555.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DEFINE_DEVICETREE(xl9555, struct Xl9555Config)
+
+#ifdef __cplusplus
+}
+#endif

--- a/Drivers/xl9555-module/include/drivers/xl9555.h
+++ b/Drivers/xl9555-module/include/drivers/xl9555.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct Xl9555Config {
+    /** Address on bus */
+    uint8_t address;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/Drivers/xl9555-module/include/xl9555_module.h
+++ b/Drivers/xl9555-module/include/xl9555_module.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tactility/module.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern struct Module xl9555_module;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Drivers/xl9555-module/source/module.cpp
+++ b/Drivers/xl9555-module/source/module.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <tactility/check.h>
+#include <tactility/driver.h>
+#include <tactility/module.h>
+
+extern "C" {
+
+extern Driver xl9555_driver;
+
+static error_t start() {
+    /* We crash when construct fails, because if a single driver fails to construct,
+     * there is no guarantee that the previously constructed drivers can be destroyed */
+    check(driver_construct_add(&xl9555_driver) == ERROR_NONE);
+    return ERROR_NONE;
+}
+
+static error_t stop() {
+    /* We crash when destruct fails, because if a single driver fails to destruct,
+     * there is no guarantee that the previously destroyed drivers can be recovered */
+    check(driver_remove_destruct(&xl9555_driver) == ERROR_NONE);
+    return ERROR_NONE;
+}
+
+Module xl9555_module = {
+    .name = "xl9555",
+    .start = start,
+    .stop = stop,
+    .symbols = nullptr,
+    .internal = nullptr
+};
+
+}

--- a/Drivers/xl9555-module/source/xl9555.cpp
+++ b/Drivers/xl9555-module/source/xl9555.cpp
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <drivers/xl9555.h>
+#include <xl9555_module.h>
+#include <tactility/device.h>
+#include <tactility/driver.h>
+#include <tactility/drivers/gpio_controller.h>
+#include <tactility/drivers/gpio_descriptor.h>
+#include <tactility/drivers/i2c_controller.h>
+#include <tactility/log.h>
+
+#define TAG "XL9555"
+
+#define GET_CONFIG(device) (static_cast<const Xl9555Config*>((device)->config))
+
+// PCA9555-compatible register map: one register per function per 8-pin port.
+constexpr auto XL9555_REGISTER_INPUT_PORT0 = 0x00;
+constexpr auto XL9555_REGISTER_OUTPUT_PORT0 = 0x02;
+constexpr auto XL9555_REGISTER_POLARITY_PORT0 = 0x04;
+constexpr auto XL9555_REGISTER_CONFIG_PORT0 = 0x06;
+
+static inline uint8_t port_of(GpioDescriptor* descriptor) {
+    return descriptor->pin >> 3;
+}
+
+static inline uint8_t bit_of(GpioDescriptor* descriptor) {
+    return 1 << (descriptor->pin & 0x7);
+}
+
+static error_t start(Device* device) {
+    auto* parent = device_get_parent(device);
+    if (device_get_type(parent) != &I2C_CONTROLLER_TYPE) {
+        LOG_E(TAG, "Parent device is not I2C");
+        return ERROR_RESOURCE;
+    }
+    LOG_I(TAG, "Started XL9555 device %s", device->name);
+
+    return gpio_controller_init_descriptors(device, 16, nullptr);
+}
+
+static error_t stop(Device* device) {
+    check(gpio_controller_deinit_descriptors(device) == ERROR_NONE);
+    return ERROR_NONE;
+}
+
+extern "C" {
+
+static error_t set_level(GpioDescriptor* descriptor, bool high) {
+    auto* device = descriptor->controller;
+    auto* parent = device_get_parent(device);
+    auto address = GET_CONFIG(device)->address;
+    auto reg = static_cast<uint8_t>(XL9555_REGISTER_OUTPUT_PORT0 + port_of(descriptor));
+    auto bit = bit_of(descriptor);
+
+    if (high) {
+        return i2c_controller_register8_set_bits(parent, address, reg, bit, portMAX_DELAY);
+    } else {
+        return i2c_controller_register8_reset_bits(parent, address, reg, bit, portMAX_DELAY);
+    }
+}
+
+static error_t get_level(GpioDescriptor* descriptor, bool* high) {
+    auto* device = descriptor->controller;
+    auto* parent = device_get_parent(device);
+    auto address = GET_CONFIG(device)->address;
+    auto reg = static_cast<uint8_t>(XL9555_REGISTER_INPUT_PORT0 + port_of(descriptor));
+    uint8_t bits;
+
+    error_t err = i2c_controller_register8_get(parent, address, reg, &bits, portMAX_DELAY);
+    if (err != ERROR_NONE) {
+        return err;
+    }
+
+    *high = (bits & bit_of(descriptor)) != 0;
+    return ERROR_NONE;
+}
+
+static error_t set_flags(GpioDescriptor* descriptor, gpio_flags_t flags) {
+    // The XL9555 only supports direction and polarity inversion. Pull-up/down and
+    // high-impedance are not present in its PCA9555-compatible register map.
+    if (flags & (GPIO_FLAG_PULL_UP | GPIO_FLAG_PULL_DOWN | GPIO_FLAG_HIGH_IMPEDANCE)) {
+        return ERROR_NOT_SUPPORTED;
+    }
+
+    auto* device = descriptor->controller;
+    auto* parent = device_get_parent(device);
+    auto address = GET_CONFIG(device)->address;
+    auto config_reg = static_cast<uint8_t>(XL9555_REGISTER_CONFIG_PORT0 + port_of(descriptor));
+    auto polarity_reg = static_cast<uint8_t>(XL9555_REGISTER_POLARITY_PORT0 + port_of(descriptor));
+    auto bit = bit_of(descriptor);
+    error_t err;
+
+    // Direction: configuration bit is 1 for input, 0 for output.
+    if (flags & GPIO_FLAG_DIRECTION_OUTPUT) {
+        err = i2c_controller_register8_reset_bits(parent, address, config_reg, bit, portMAX_DELAY);
+    } else {
+        err = i2c_controller_register8_set_bits(parent, address, config_reg, bit, portMAX_DELAY);
+    }
+
+    if (err != ERROR_NONE) {
+        return err;
+    }
+
+    // Polarity inversion (mainly relevant for active-low inputs).
+    if (flags & GPIO_FLAG_ACTIVE_LOW) {
+        err = i2c_controller_register8_set_bits(parent, address, polarity_reg, bit, portMAX_DELAY);
+    } else {
+        err = i2c_controller_register8_reset_bits(parent, address, polarity_reg, bit, portMAX_DELAY);
+    }
+
+    return err;
+}
+
+static error_t get_flags(GpioDescriptor* descriptor, gpio_flags_t* flags) {
+    auto* device = descriptor->controller;
+    auto* parent = device_get_parent(device);
+    auto address = GET_CONFIG(device)->address;
+    auto config_reg = static_cast<uint8_t>(XL9555_REGISTER_CONFIG_PORT0 + port_of(descriptor));
+    auto polarity_reg = static_cast<uint8_t>(XL9555_REGISTER_POLARITY_PORT0 + port_of(descriptor));
+    auto bit = bit_of(descriptor);
+    uint8_t val;
+    error_t err;
+
+    gpio_flags_t f = GPIO_FLAG_NONE;
+
+    err = i2c_controller_register8_get(parent, address, config_reg, &val, portMAX_DELAY);
+    if (err != ERROR_NONE) return err;
+    f |= (val & bit) ? GPIO_FLAG_DIRECTION_INPUT : GPIO_FLAG_DIRECTION_OUTPUT;
+
+    err = i2c_controller_register8_get(parent, address, polarity_reg, &val, portMAX_DELAY);
+    if (err != ERROR_NONE) return err;
+    f |= (val & bit) ? GPIO_FLAG_ACTIVE_LOW : GPIO_FLAG_ACTIVE_HIGH;
+
+    *flags = f;
+    return ERROR_NONE;
+}
+
+static error_t get_native_pin_number(GpioDescriptor* descriptor, void* pin_number) {
+    return ERROR_NOT_SUPPORTED;
+}
+
+static error_t add_callback(GpioDescriptor* descriptor, void (*callback)(void*), void* arg) {
+    return ERROR_NOT_SUPPORTED;
+}
+
+static error_t remove_callback(GpioDescriptor* descriptor) {
+    return ERROR_NOT_SUPPORTED;
+}
+
+static error_t enable_interrupt(GpioDescriptor* descriptor) {
+    return ERROR_NOT_SUPPORTED;
+}
+
+static error_t disable_interrupt(GpioDescriptor* descriptor) {
+    return ERROR_NOT_SUPPORTED;
+}
+
+const static GpioControllerApi xl9555_gpio_api = {
+    .set_level = set_level,
+    .get_level = get_level,
+    .set_flags = set_flags,
+    .get_flags = get_flags,
+    .get_native_pin_number = get_native_pin_number,
+    .add_callback = add_callback,
+    .remove_callback = remove_callback,
+    .enable_interrupt = enable_interrupt,
+    .disable_interrupt = disable_interrupt
+};
+
+Driver xl9555_driver = {
+    .name = "xl9555",
+    .compatible = (const char*[]) { "xlsemi,xl9555", nullptr },
+    .start_device = start,
+    .stop_device = stop,
+    .api = static_cast<const void*>(&xl9555_gpio_api),
+    .device_type = &GPIO_CONTROLLER_TYPE,
+    .owner = &xl9555_module,
+    .internal = nullptr
+};
+
+}

--- a/Tests/SdkIntegration/main/CMakeLists.txt
+++ b/Tests/SdkIntegration/main/CMakeLists.txt
@@ -10,4 +10,5 @@ idf_component_register(
         pi4ioe5v6408-module
         qmi8658-module
         rx8130ce-module
+        xl9555-module
 )


### PR DESCRIPTION
First piece of the T-Deck Pro Max port (see github.com/Crazypedia/T-Deck-MAX for hardware notes). Almost every other peripheral on that board (touch reset, keyboard reset, LoRa/GPS/modem power enables, antenna and audio routing) gates through the XL9555, so it needs to land before the rest.

Follows the pi4ioe5v6408-module pattern, using the XL9555's PCA9555-compatible register map (16 pins across two 8-bit ports).


Claude-Session: https://claude.ai/code/session_01ABK7pfLhWE7hPGcgHHTbKu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the XL9555/PCA9555 16-bit I2C GPIO expander device, enabling independent control of 16 GPIO pins through an I2C bus with configurable input/output direction and active-low/active-high polarity settings for each pin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->