### PR TITLE
Update properties parsing for app manifest and device manifest files

### DIFF
--- a/Buildscripts/CDN/generate-firmware-files.py
+++ b/Buildscripts/CDN/generate-firmware-files.py
@@ -2,11 +2,9 @@ import subprocess
 from datetime import datetime, UTC
 import os
 import sys
-import configparser
 from dataclasses import dataclass, asdict
 import json
 import shutil
-from configparser import RawConfigParser
 
 VERBOSE = False
 DEVICES_FOLDER = "Devices"
@@ -68,32 +66,29 @@ def exit_with_error(message):
     sys.exit(1)
 
 def read_properties_file(path):
-    config = configparser.RawConfigParser()
-    # Don't convert keys to lowercase
-    config.optionxform = str
-    config.read(path)
-    return config
+    properties = {}
+    with open(path, "r") as file:
+        for line in file:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            key, sep, value = line.partition("=")
+            if not sep:
+                continue
+            properties[key.strip()] = value.strip()
+    return properties
 
-def get_property_or_none(properties: RawConfigParser, group: str, key: str):
-    if group not in properties.sections():
-        return None
-    if key not in properties[group].keys():
-        return None
-    return properties[group][key]
+def get_property_or_none(properties: dict, group: str, key: str):
+    return properties.get(f"{group}.{key}")
 
-def get_boolean_property_or_false(properties: RawConfigParser, group: str, key: str):
-    if group not in properties.sections():
-        return False
-    if key not in properties[group].keys():
-        return False
-    return properties[group][key] == "true"
+def get_boolean_property_or_false(properties: dict, group: str, key: str):
+    return properties.get(f"{group}.{key}") == "true"
 
-def get_property_or_exit(properties: RawConfigParser, group: str, key: str):
-    if group not in properties.sections():
-        exit_with_error(f"Device properties does not contain group: {group}")
-    if key not in properties[group].keys():
-        exit_with_error(f"Device properties does not contain key: {key}")
-    return properties[group][key]
+def get_property_or_exit(properties: dict, group: str, key: str):
+    full_key = f"{group}.{key}"
+    if full_key not in properties:
+        exit_with_error(f"Device properties does not contain key: {full_key}")
+    return properties[full_key]
 
 def read_device_properties(device_id):
     mapping_file_path = os.path.join(DEVICES_FOLDER, device_id, "device.properties")
@@ -129,7 +124,7 @@ def to_manifest_chip_name(name):
         return ""
 
 
-def process_device(in_path: str, out_path: str, device_directory: str, device_id: str, device_properties: RawConfigParser, version: str):
+def process_device(in_path: str, out_path: str, device_directory: str, device_id: str, device_properties: dict, version: str):
     in_device_path = os.path.join(in_path, device_directory)
     in_device_binaries_path = os.path.join(in_device_path, "Binaries")
     if not os.path.isdir(in_device_binaries_path):

--- a/Buildscripts/properties.cmake
+++ b/Buildscripts/properties.cmake
@@ -28,7 +28,6 @@ function(READ_PROPERTIES_TO_MAP PROPERTY_FILE RESULT_VAR)
     endif ()
 
     file(STRINGS ${PROPERTY_FILE_ABS} lines)
-    set(current_section "")
     set(map_content "")
 
     foreach(line IN LISTS lines)
@@ -37,9 +36,7 @@ function(READ_PROPERTIES_TO_MAP PROPERTY_FILE RESULT_VAR)
             continue()
         endif ()
 
-        if (line MATCHES "^\\[.*\\]$")
-            set(current_section "${line}")
-        elseif (line MATCHES "^([^=]+)=(.*)$")
+        if (line MATCHES "^([^=]+)=(.*)$")
             set(key "${CMAKE_MATCH_1}")
             set(value "${CMAKE_MATCH_2}")
             string(STRIP "${key}" key)
@@ -49,7 +46,7 @@ function(READ_PROPERTIES_TO_MAP PROPERTY_FILE RESULT_VAR)
                 set(value "${CMAKE_MATCH_1}")
             endif ()
 
-            list(APPEND map_content "${current_section}${key}" "${value}")
+            list(APPEND map_content "${key}" "${value}")
         endif ()
     endforeach()
 

--- a/Devices/btt-panda-touch/device.properties
+++ b/Devices/btt-panda-touch/device.properties
@@ -1,25 +1,20 @@
-[general]
-vendor=BigTreeTech
-name=Panda Touch,K Touch
+general.vendor=BigTreeTech
+general.name=Panda Touch,K Touch
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-esptoolFlashFreq=120M
-bluetooth=true
-usbHostEnabled=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
+hardware.usbHostEnabled=true
 
-[display]
-size=5"
-shape=rectangle
-dpi=187
+display.size=5"
+display.shape=rectangle
+display.dpi=187
 
-[lvgl]
-colorDepth=16
-fontSize=18
+lvgl.colorDepth=16
+lvgl.fontSize=18

--- a/Devices/cyd-2432s024c/device.properties
+++ b/Devices/cyd-2432s024c/device.properties
@@ -1,19 +1,14 @@
-[general]
-vendor=CYD
-name=2432S024C
+general.vendor=CYD
+general.name=2432S024C
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=2.4"
-shape=rectangle
-dpi=167
+display.size=2.4"
+display.shape=rectangle
+display.dpi=167
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/cyd-2432s024r/device.properties
+++ b/Devices/cyd-2432s024r/device.properties
@@ -1,19 +1,14 @@
-[general]
-vendor=CYD
-name=2432S024R
+general.vendor=CYD
+general.name=2432S024R
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=2.4"
-shape=rectangle
-dpi=167
+display.size=2.4"
+display.shape=rectangle
+display.dpi=167
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/cyd-2432s028r/device.properties
+++ b/Devices/cyd-2432s028r/device.properties
@@ -1,22 +1,16 @@
-[general]
-vendor=CYD
-name=2432S028R
+general.vendor=CYD
+general.name=2432S028R
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=2.8"
-shape=rectangle
-dpi=143
+display.size=2.8"
+display.shape=rectangle
+display.dpi=143
 
-[cdn]
-warningMessage=There are 3 hardware variants of this board. This build works on the original variant only ("v1").
+cdn.warningMessage=There are 3 hardware variants of this board. This build works on the original variant only ("v1").
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/cyd-2432s028rv3/device.properties
+++ b/Devices/cyd-2432s028rv3/device.properties
@@ -1,22 +1,16 @@
-[general]
-vendor=CYD
-name=2432S028R v3
+general.vendor=CYD
+general.name=2432S028R v3
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=2.8"
-shape=rectangle
-dpi=143
+display.size=2.8"
+display.shape=rectangle
+display.dpi=143
 
-[cdn]
-warningMessage=There are 3 hardware variants of this board. This build only supports board version 3.
+cdn.warningMessage=There are 3 hardware variants of this board. This build only supports board version 3.
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/cyd-2432s032c/device.properties
+++ b/Devices/cyd-2432s032c/device.properties
@@ -1,19 +1,14 @@
-[general]
-vendor=CYD
-name=2432S032C
+general.vendor=CYD
+general.name=2432S032C
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=3.2"
-shape=rectangle
-dpi=125
+display.size=3.2"
+display.shape=rectangle
+display.dpi=125
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/cyd-3248s035c/device.properties
+++ b/Devices/cyd-3248s035c/device.properties
@@ -1,19 +1,14 @@
-[general]
-vendor=CYD
-name=3248S035C
+general.vendor=CYD
+general.name=3248S035C
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=3.5"
-shape=rectangle
-dpi=165
+display.size=3.5"
+display.shape=rectangle
+display.dpi=165
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/cyd-4848s040c/device.properties
+++ b/Devices/cyd-4848s040c/device.properties
@@ -1,22 +1,17 @@
-[general]
-vendor=CYD
-name=4848S040C
+general.vendor=CYD
+general.name=4848S040C
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=80M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=80M
+hardware.bluetooth=true
 
-[display]
-size=4"
-shape=rectangle
-dpi=170
+display.size=4"
+display.shape=rectangle
+display.dpi=170
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/cyd-8048s043c/device.properties
+++ b/Devices/cyd-8048s043c/device.properties
@@ -1,30 +1,24 @@
-[general]
-vendor=CYD
-name=8048S043C
-incubating=false
+general.vendor=CYD
+general.name=8048S043C
+general.incubating=false
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=80M
-esptoolFlashFreq=80M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=80M
+hardware.esptoolFlashFreq=80M
+hardware.bluetooth=true
 
-[display]
-size=4.3"
-shape=rectangle
-dpi=217
+display.size=4.3"
+display.shape=rectangle
+display.dpi=217
 
-[cdn]
-infoMessage=
-warningMessage=
+cdn.infoMessage=
+cdn.warningMessage=
 
-[lvgl]
-theme=DefaultDark
-colorDepth=16
-fontSize=18
+lvgl.theme=DefaultDark
+lvgl.colorDepth=16
+lvgl.fontSize=18

--- a/Devices/cyd-e32r28t/device.properties
+++ b/Devices/cyd-e32r28t/device.properties
@@ -1,19 +1,14 @@
-[general]
-vendor=CYD
-name=E32R28T
+general.vendor=CYD
+general.name=E32R28T
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=2.8"
-shape=rectangle
-dpi=143
+display.size=2.8"
+display.shape=rectangle
+display.dpi=143
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/cyd-e32r32p/device.properties
+++ b/Devices/cyd-e32r32p/device.properties
@@ -1,19 +1,14 @@
-[general]
-vendor=CYD
-name=E32R32P
+general.vendor=CYD
+general.name=E32R32P
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=2.8"
-shape=rectangle
-dpi=125
+display.size=2.8"
+display.shape=rectangle
+display.dpi=125
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/elecrow-crowpanel-advance-28/device.properties
+++ b/Devices/elecrow-crowpanel-advance-28/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=Elecrow
-name=CrowPanel Advance 2.8"
+general.vendor=Elecrow
+general.name=CrowPanel Advance 2.8"
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=2.8"
-shape=rectangle
-dpi=143
+display.size=2.8"
+display.shape=rectangle
+display.dpi=143
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/elecrow-crowpanel-advance-35/device.properties
+++ b/Devices/elecrow-crowpanel-advance-35/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=Elecrow
-name=CrowPanel Advance 3.5"
+general.vendor=Elecrow
+general.name=CrowPanel Advance 3.5"
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=3.5"
-shape=rectangle
-dpi=165
+display.size=3.5"
+display.shape=rectangle
+display.dpi=165
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/elecrow-crowpanel-advance-50/device.properties
+++ b/Devices/elecrow-crowpanel-advance-50/device.properties
@@ -1,25 +1,20 @@
-[general]
-vendor=Elecrow
-name=CrowPanel Advance 5.0"
+general.vendor=Elecrow
+general.name=CrowPanel Advance 5.0"
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=5"
-shape=rectangle
-dpi=187
+display.size=5"
+display.shape=rectangle
+display.dpi=187
 
-[lvgl]
-colorDepth=16
-fontSize=18
+lvgl.colorDepth=16
+lvgl.fontSize=18

--- a/Devices/elecrow-crowpanel-basic-28/device.properties
+++ b/Devices/elecrow-crowpanel-basic-28/device.properties
@@ -1,19 +1,14 @@
-[general]
-vendor=Elecrow
-name=CrowPanel Basic 2.8"
+general.vendor=Elecrow
+general.name=CrowPanel Basic 2.8"
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=2.8"
-shape=rectangle
-dpi=143
+display.size=2.8"
+display.shape=rectangle
+display.dpi=143
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/elecrow-crowpanel-basic-35/device.properties
+++ b/Devices/elecrow-crowpanel-basic-35/device.properties
@@ -1,19 +1,14 @@
-[general]
-vendor=Elecrow
-name=CrowPanel Basic 3.5"
+general.vendor=Elecrow
+general.name=CrowPanel Basic 3.5"
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=3.5"
-shape=rectangle
-dpi=165
+display.size=3.5"
+display.shape=rectangle
+display.dpi=165
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/elecrow-crowpanel-basic-50/device.properties
+++ b/Devices/elecrow-crowpanel-basic-50/device.properties
@@ -1,25 +1,20 @@
-[general]
-vendor=Elecrow
-name=CrowPanel Basic 5.0"
+general.vendor=Elecrow
+general.name=CrowPanel Basic 5.0"
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=4MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=4MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=5.0"
-shape=rectangle
-dpi=187
+display.size=5.0"
+display.shape=rectangle
+display.dpi=187
 
-[lvgl]
-colorDepth=16
-fontSize=18
+lvgl.colorDepth=16
+lvgl.fontSize=18

--- a/Devices/generic-esp32/device.properties
+++ b/Devices/generic-esp32/device.properties
@@ -1,12 +1,9 @@
-[general]
-vendor=Generic
-name=ESP32
+general.vendor=Generic
+general.name=ESP32
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 

--- a/Devices/generic-esp32c6/device.properties
+++ b/Devices/generic-esp32c6/device.properties
@@ -1,12 +1,9 @@
-[general]
-vendor=Generic
-name=ESP32-C6
+general.vendor=Generic
+general.name=ESP32-C6
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32C6
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32C6
+hardware.flashSize=4MB
+hardware.spiRam=false
 

--- a/Devices/generic-esp32p4/device.properties
+++ b/Devices/generic-esp32p4/device.properties
@@ -1,12 +1,9 @@
-[general]
-vendor=Generic
-name=ESP32-P4
+general.vendor=Generic
+general.name=ESP32-P4
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32P4
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32P4
+hardware.flashSize=4MB
+hardware.spiRam=false
 

--- a/Devices/generic-esp32s3/device.properties
+++ b/Devices/generic-esp32s3/device.properties
@@ -1,12 +1,9 @@
-[general]
-vendor=Generic
-name=ESP32-S3
+general.vendor=Generic
+general.name=ESP32-S3
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32S3
+hardware.flashSize=4MB
+hardware.spiRam=false
 

--- a/Devices/guition-jc1060p470ciwy/device.properties
+++ b/Devices/guition-jc1060p470ciwy/device.properties
@@ -1,33 +1,27 @@
-[general]
-vendor=Guition
-name=JC1060P470C-I-W-Y
+general.vendor=Guition
+general.name=JC1060P470C-I-W-Y
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32P4
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=200M
-esptoolFlashFreq=80M
-bluetooth=true
+hardware.target=ESP32P4
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=200M
+hardware.esptoolFlashFreq=80M
+hardware.bluetooth=true
 
-[display]
-size=7"
-shape=rectangle
-dpi=187
+display.size=7"
+display.shape=rectangle
+display.dpi=187
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16
 
-[sdkconfig]
-CONFIG_WIFI_PROV_SCAN_MAX_ENTRIES=16
-CONFIG_WIFI_PROV_AUTOSTOP_TIMEOUT=30
-CONFIG_WIFI_PROV_STA_ALL_CHANNEL_SCAN=y
-CONFIG_ESP_HOSTED_ENABLED=y
-CONFIG_ESP_HOSTED_P4_DEV_BOARD_FUNC_BOARD=y
-CONFIG_ESP_HOSTED_SDIO_HOST_INTERFACE=y
-CONFIG_SLAVE_IDF_TARGET_ESP32C6=y
-CONFIG_ESP_HOSTED_USE_MEMPOOL=n
+sdkconfig.CONFIG_WIFI_PROV_SCAN_MAX_ENTRIES=16
+sdkconfig.CONFIG_WIFI_PROV_AUTOSTOP_TIMEOUT=30
+sdkconfig.CONFIG_WIFI_PROV_STA_ALL_CHANNEL_SCAN=y
+sdkconfig.CONFIG_ESP_HOSTED_ENABLED=y
+sdkconfig.CONFIG_ESP_HOSTED_P4_DEV_BOARD_FUNC_BOARD=y
+sdkconfig.CONFIG_ESP_HOSTED_SDIO_HOST_INTERFACE=y
+sdkconfig.CONFIG_SLAVE_IDF_TARGET_ESP32C6=y
+sdkconfig.CONFIG_ESP_HOSTED_USE_MEMPOOL=n

--- a/Devices/guition-jc2432w328c/device.properties
+++ b/Devices/guition-jc2432w328c/device.properties
@@ -1,19 +1,14 @@
-[general]
-vendor=Guition
-name=JC2432W328C
+general.vendor=Guition
+general.name=JC2432W328C
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
 
-[display]
-size=2.8"
-shape=rectangle
-dpi=143
+display.size=2.8"
+display.shape=rectangle
+display.dpi=143
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/guition-jc3248w535c/device.properties
+++ b/Devices/guition-jc3248w535c/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=Guition
-name=JC3248W535C
+general.vendor=Guition
+general.name=JC3248W535C
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=3.5"
-shape=rectangle
-dpi=165
+display.size=3.5"
+display.shape=rectangle
+display.dpi=165
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/guition-jc8048w550c/device.properties
+++ b/Devices/guition-jc8048w550c/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=Guition
-name=JC8048W550C
+general.vendor=Guition
+general.name=JC8048W550C
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=80M
-esptoolFlashFreq=80M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=80M
+hardware.esptoolFlashFreq=80M
+hardware.bluetooth=true
 
-[display]
-size=5"
-shape=rectangle
-dpi=187
+display.size=5"
+display.shape=rectangle
+display.dpi=187
 
-[lvgl]
-colorDepth=16
-fontSize=18
+lvgl.colorDepth=16
+lvgl.fontSize=18

--- a/Devices/heltec-wifi-lora-32-v3/device.properties
+++ b/Devices/heltec-wifi-lora-32-v3/device.properties
@@ -1,30 +1,24 @@
-[general]
-vendor=Heltec
-name=WiFi LoRa 32 v3
-incubating=true
+general.vendor=Heltec
+general.name=WiFi LoRa 32 v3
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32S3
-flashSize=8MB
-spiRam=false
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=8MB
+hardware.spiRam=false
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=0.96"
-shape=rectangle
-dpi=149
+display.size=0.96"
+display.shape=rectangle
+display.dpi=149
 
-[cdn]
-infoMessage=Due to the small size of the screen, the icons don't render properly.
+cdn.infoMessage=Due to the small size of the screen, the icons don't render properly.
 
-[lvgl]
-theme=Mono
-colorDepth=16
-uiScale=70
-uiDensity=compact
+lvgl.theme=Mono
+lvgl.colorDepth=16
+lvgl.uiScale=70
+lvgl.uiDensity=compact

--- a/Devices/lilygo-tdeck/device.properties
+++ b/Devices/lilygo-tdeck/device.properties
@@ -1,27 +1,21 @@
-[general]
-vendor=LilyGO
-name=T-Deck,T-Deck Plus
+general.vendor=LilyGO
+general.name=T-Deck,T-Deck Plus
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=2.8"
-shape=rectangle
-dpi=143
+display.size=2.8"
+display.shape=rectangle
+display.dpi=143
 
-[cdn]
-infoMessage=To put the device into bootloader mode: <br/>1. Press the trackball and then the reset button at the same time,<br/>2. Let go of the reset button, then the trackball.<br/><br/>When this website reports that flashing is finished, you likely have to press the reset button.
+cdn.infoMessage=To put the device into bootloader mode: <br/>1. Press the trackball and then the reset button at the same time,<br/>2. Let go of the reset button, then the trackball.<br/><br/>When this website reports that flashing is finished, you likely have to press the reset button.
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/lilygo-tdisplay-s3/device.properties
+++ b/Devices/lilygo-tdisplay-s3/device.properties
@@ -1,25 +1,20 @@
-[general]
-vendor=LilyGO
-name=T-Display S3
+general.vendor=LilyGO
+general.name=T-Display S3
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=1.9"
-shape=rectangle
-dpi=191
+display.size=1.9"
+display.shape=rectangle
+display.dpi=191
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/lilygo-tdisplay/device.properties
+++ b/Devices/lilygo-tdisplay/device.properties
@@ -1,23 +1,18 @@
-[general]
-vendor=LilyGO
-name=T-Display
-incubating=true
+general.vendor=LilyGO
+general.name=T-Display
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32
-flashSize=16MB
-spiRam=false
-esptoolFlashFreq=80M
+hardware.target=ESP32
+hardware.flashSize=16MB
+hardware.spiRam=false
+hardware.esptoolFlashFreq=80M
 
-[display]
-size=1.14"
-shape=rectangle
-dpi=242
+display.size=1.14"
+display.shape=rectangle
+display.dpi=242
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact

--- a/Devices/lilygo-tdongle-s3/device.properties
+++ b/Devices/lilygo-tdongle-s3/device.properties
@@ -1,26 +1,21 @@
-[general]
-vendor=LilyGO
-name=T-Dongle S3
-incubating=true
+general.vendor=LilyGO
+general.name=T-Dongle S3
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=false
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=false
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=0.96"
-shape=rectangle
-dpi=186
+display.size=0.96"
+display.shape=rectangle
+display.dpi=186
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
-fontSize=10
+lvgl.colorDepth=16
+lvgl.uiDensity=compact
+lvgl.fontSize=10

--- a/Devices/lilygo-thmi/device.properties
+++ b/Devices/lilygo-thmi/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=LilyGO
-name=T-HMI
+general.vendor=LilyGO
+general.name=T-HMI
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=2.8"
-shape=rectangle
-dpi=125
+display.size=2.8"
+display.shape=rectangle
+display.dpi=125
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/lilygo-tlora-pager/device.properties
+++ b/Devices/lilygo-tlora-pager/device.properties
@@ -1,26 +1,21 @@
-[general]
-vendor=LilyGO
-name=T-Lora Pager
+general.vendor=LilyGO
+general.name=T-Lora Pager
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-flashMode=DIO
-spiRam=true
-spiRamMode=AUTO
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=40M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.flashMode=DIO
+hardware.spiRam=true
+hardware.spiRamMode=AUTO
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=40M
+hardware.bluetooth=true
 
-[display]
-size=2.33"
-shape=rectangle
-dpi=227
+display.size=2.33"
+display.shape=rectangle
+display.dpi=227
 
-[lvgl]
-colorDepth=16
-dpi=150
+lvgl.colorDepth=16
+lvgl.dpi=150

--- a/Devices/m5stack-cardputer-adv/device.properties
+++ b/Devices/m5stack-cardputer-adv/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=M5Stack
-name=Cardputer Adv
+general.vendor=M5Stack
+general.name=Cardputer Adv
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=8MB
-spiRam=false
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=8MB
+hardware.spiRam=false
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=1.14"
-shape=rectangle
+display.size=1.14"
+display.shape=rectangle
 # TODO: dps is actually 242, but this breaks UI (button selection becomes invisible and switch visibility is reduced)
-dpi=139
+display.dpi=139
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact

--- a/Devices/m5stack-cardputer/device.properties
+++ b/Devices/m5stack-cardputer/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=M5Stack
-name=Cardputer,Cardputer v1.1
+general.vendor=M5Stack
+general.name=Cardputer,Cardputer v1.1
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=8MB
-spiRam=false
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=8MB
+hardware.spiRam=false
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=1.14"
-shape=rectangle
+display.size=1.14"
+display.shape=rectangle
 # TODO: dps is actually 242, but this breaks UI (button selection becomes invisible and switch visibility is reduced)
-dpi=139
+display.dpi=139
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact

--- a/Devices/m5stack-core2/device.properties
+++ b/Devices/m5stack-core2/device.properties
@@ -1,25 +1,19 @@
-[general]
-vendor=M5Stack
-name=Core2
+general.vendor=M5Stack
+general.name=Core2
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32
-flashSize=16MB
-spiRam=true
-spiRamMode=QUAD
-spiRamSpeed=80M
-esptoolFlashFreq=80M
+hardware.target=ESP32
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=QUAD
+hardware.spiRamSpeed=80M
+hardware.esptoolFlashFreq=80M
 
-[display]
-size=2"
-shape=rectangle
-dpi=200
+display.size=2"
+display.shape=rectangle
+display.dpi=200
 
-[cdn]
-warningMessage=This board implementation concerns the original Core2 hardware and **not** the v1.1 variant
+cdn.warningMessage=This board implementation concerns the original Core2 hardware and **not** the v1.1 variant
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/m5stack-cores3/device.properties
+++ b/Devices/m5stack-cores3/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=M5Stack
-name=CoreS3
+general.vendor=M5Stack
+general.name=CoreS3
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=QUAD
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=QUAD
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=2"
-shape=rectangle
-dpi=200
+display.size=2"
+display.shape=rectangle
+display.dpi=200
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/m5stack-papers3/device.properties
+++ b/Devices/m5stack-papers3/device.properties
@@ -1,32 +1,26 @@
-[general]
-vendor=M5Stack
-name=PaperS3
-incubating=true
+general.vendor=M5Stack
+general.name=PaperS3
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=esp32s3
-flashSize=16MB
-spiRam=true
-spiRamMode=OPI
-spiRamSpeed=80M
-esptoolFlashFreq=80M
-tinyUsb=true
-bluetooth=true
+hardware.target=esp32s3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OPI
+hardware.spiRamSpeed=80M
+hardware.esptoolFlashFreq=80M
+hardware.tinyUsb=true
+hardware.bluetooth=true
 
-[display]
-size=4.7"
-shape=rectangle
-dpi=235
+display.size=4.7"
+display.shape=rectangle
+display.dpi=235
 
-[lvgl]
-colorDepth=8
-fontSize=24
-theme=Mono
+lvgl.colorDepth=8
+lvgl.fontSize=24
+lvgl.theme=Mono
 
-[sdkconfig]
-CONFIG_EPD_DISPLAY_TYPE_ED047TC2=y
+sdkconfig.CONFIG_EPD_DISPLAY_TYPE_ED047TC2=y
 
 

--- a/Devices/m5stack-stackchan/device.properties
+++ b/Devices/m5stack-stackchan/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=M5Stack
-name=StackChan
+general.vendor=M5Stack
+general.name=StackChan
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=QUAD
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=QUAD
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=2"
-shape=rectangle
-dpi=200
+display.size=2"
+display.shape=rectangle
+display.dpi=200
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Devices/m5stack-stickc-plus/device.properties
+++ b/Devices/m5stack-stickc-plus/device.properties
@@ -1,23 +1,18 @@
-[general]
-vendor=M5Stack
-name=StickC Plus
-incubating=true
+general.vendor=M5Stack
+general.name=StickC Plus
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32
-flashSize=4MB
-spiRam=false
-esptoolFlashFreq=80M
+hardware.target=ESP32
+hardware.flashSize=4MB
+hardware.spiRam=false
+hardware.esptoolFlashFreq=80M
 
-[display]
-size=1.14"
-shape=rectangle
-dpi=242
+display.size=1.14"
+display.shape=rectangle
+display.dpi=242
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact

--- a/Devices/m5stack-stickc-plus2/device.properties
+++ b/Devices/m5stack-stickc-plus2/device.properties
@@ -1,25 +1,20 @@
-[general]
-vendor=M5Stack
-name=StickC Plus2
-incubating=true
+general.vendor=M5Stack
+general.name=StickC Plus2
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32
-flashSize=8MB
-spiRam=true
-spiRamMode=QUAD
-spiRamSpeed=80M
-esptoolFlashFreq=80M
+hardware.target=ESP32
+hardware.flashSize=8MB
+hardware.spiRam=true
+hardware.spiRamMode=QUAD
+hardware.spiRamSpeed=80M
+hardware.esptoolFlashFreq=80M
 
-[display]
-size=1.14"
-shape=rectangle
-dpi=242
+display.size=1.14"
+display.shape=rectangle
+display.dpi=242
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact

--- a/Devices/m5stack-sticks3/device.properties
+++ b/Devices/m5stack-sticks3/device.properties
@@ -1,25 +1,20 @@
-[general]
-vendor=M5Stack
-name=StickS3
+general.vendor=M5Stack
+general.name=StickS3
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=8MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=80M
-esptoolFlashFreq=80M
-tinyUsb=true
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=8MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=80M
+hardware.esptoolFlashFreq=80M
+hardware.tinyUsb=true
+hardware.bluetooth=true
 
-[display]
-size=1.14"
-shape=rectangle
-dpi=242
+display.size=1.14"
+display.shape=rectangle
+display.dpi=242
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact

--- a/Devices/m5stack-tab5/device.properties
+++ b/Devices/m5stack-tab5/device.properties
@@ -1,51 +1,45 @@
-[general]
-vendor=M5Stack
-name=Tab5
+general.vendor=M5Stack
+general.name=Tab5
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32P4
-flashSize=16MB
-spiRam=true
-spiRamMode=HEX
-spiRamSpeed=200M
-esptoolFlashFreq=80M
-bluetooth=true
-usbHostEnabled=true
-tinyUsb=true
+hardware.target=ESP32P4
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=HEX
+hardware.spiRamSpeed=200M
+hardware.esptoolFlashFreq=80M
+hardware.bluetooth=true
+hardware.usbHostEnabled=true
+hardware.tinyUsb=true
 
-[display]
-size=5"
-shape=rectangle
-dpi=294
+display.size=5"
+display.shape=rectangle
+display.dpi=294
 
-[lvgl]
-colorDepth=16
-fontSize=28
-dpi=250
+lvgl.colorDepth=16
+lvgl.fontSize=28
+lvgl.dpi=250
 
-[sdkconfig]
-CONFIG_WIFI_PROV_SCAN_MAX_ENTRIES=16
-CONFIG_WIFI_PROV_AUTOSTOP_TIMEOUT=30
-CONFIG_WIFI_PROV_STA_ALL_CHANNEL_SCAN=y
-CONFIG_SLAVE_IDF_TARGET_ESP32C6=y
-CONFIG_ESP_HOSTED_ENABLED=y
-CONFIG_ESP_HOSTED_SDIO_HOST_INTERFACE=y
-CONFIG_ESP_HOSTED_SDIO_SLOT_1=y
-CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_CMD_SLOT_1=13
-CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_CLK_SLOT_1=12
-CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D0_SLOT_1=11
-CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D1_4BIT_BUS_SLOT_1=10
-CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D2_4BIT_BUS_SLOT_1=9
-CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D3_4BIT_BUS_SLOT_1=8
-CONFIG_ESP_HOSTED_SDIO_GPIO_RESET_SLAVE=15
+sdkconfig.CONFIG_WIFI_PROV_SCAN_MAX_ENTRIES=16
+sdkconfig.CONFIG_WIFI_PROV_AUTOSTOP_TIMEOUT=30
+sdkconfig.CONFIG_WIFI_PROV_STA_ALL_CHANNEL_SCAN=y
+sdkconfig.CONFIG_SLAVE_IDF_TARGET_ESP32C6=y
+sdkconfig.CONFIG_ESP_HOSTED_ENABLED=y
+sdkconfig.CONFIG_ESP_HOSTED_SDIO_HOST_INTERFACE=y
+sdkconfig.CONFIG_ESP_HOSTED_SDIO_SLOT_1=y
+sdkconfig.CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_CMD_SLOT_1=13
+sdkconfig.CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_CLK_SLOT_1=12
+sdkconfig.CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D0_SLOT_1=11
+sdkconfig.CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D1_4BIT_BUS_SLOT_1=10
+sdkconfig.CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D2_4BIT_BUS_SLOT_1=9
+sdkconfig.CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D3_4BIT_BUS_SLOT_1=8
+sdkconfig.CONFIG_ESP_HOSTED_SDIO_GPIO_RESET_SLAVE=15
 # Fixes recent changes to esp_hosted
-CONFIG_ESP_HOSTED_USE_MEMPOOL=n
+sdkconfig.CONFIG_ESP_HOSTED_USE_MEMPOOL=n
 # Performance: larger L2 cache reduces PSRAM stalls for draw/DPI buffers
-CONFIG_CACHE_L2_CACHE_256KB=y
+sdkconfig.CONFIG_CACHE_L2_CACHE_256KB=y
 # Performance: use P4's PPA (pixel processing accelerator for rotation)
-CONFIG_LVGL_PORT_ENABLE_PPA=y
-CONFIG_LV_DRAW_BUF_ALIGN=64
-CONFIG_LV_DEF_REFR_PERIOD=15
+sdkconfig.CONFIG_LVGL_PORT_ENABLE_PPA=y
+sdkconfig.CONFIG_LV_DRAW_BUF_ALIGN=64
+sdkconfig.CONFIG_LV_DEF_REFR_PERIOD=15

--- a/Devices/simulator/device.properties
+++ b/Devices/simulator/device.properties
@@ -1,13 +1,9 @@
-[general]
-vendor=Simulator
-name=Tab5Simulator
+general.vendor=Simulator
+general.name=Tab5Simulator
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=POSIX
+hardware.target=POSIX
 
-[lvgl]
-colorDepth=16
-fontSize=14
+lvgl.colorDepth=16
+lvgl.fontSize=14

--- a/Devices/unphone/device.properties
+++ b/Devices/unphone/device.properties
@@ -1,25 +1,19 @@
-[general]
-vendor=unPhone
-name=unPhone
+general.vendor=unPhone
+general.name=unPhone
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=8MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=80M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=8MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=80M
+hardware.bluetooth=true
 
-[display]
-size=3.5"
-shape=rectangle
-dpi=165
+display.size=3.5"
+display.shape=rectangle
+display.dpi=165
 
-[cdn]
-warningMessage=Put the device into bootloader mode by pressing the center nav button and reset for 2-3 seconds, then release reset, then release the nav button.<br/>After flashing is finished, press the reset button to reboot.
+cdn.warningMessage=Put the device into bootloader mode by pressing the center nav button and reset for 2-3 seconds, then release reset, then release the nav button.<br/>After flashing is finished, press the reset button to reboot.
 
-[lvgl]
-colorDepth=24
+lvgl.colorDepth=24

--- a/Devices/waveshare-esp32-s3-geek/device.properties
+++ b/Devices/waveshare-esp32-s3-geek/device.properties
@@ -1,33 +1,27 @@
-[general]
-vendor=Waveshare
-name=ESP32 S3 GEEK
-incubating=true
+general.vendor=Waveshare
+general.name=ESP32 S3 GEEK
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=QUAD
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=QUAD
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=1.14"
-shape=rectangle
-dpi=143
+display.size=1.14"
+display.shape=rectangle
+display.dpi=143
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact
 
-[sdkconfig]
 # Fix error "PSRAM space not enough for the Flash instructions" on boot:
-CONFIG_SPIRAM_FETCH_INSTRUCTIONS=n
-CONFIG_SPIRAM_RODATA=n
-CONFIG_SPIRAM_XIP_FROM_PSRAM=n
+sdkconfig.CONFIG_SPIRAM_FETCH_INSTRUCTIONS=n
+sdkconfig.CONFIG_SPIRAM_RODATA=n
+sdkconfig.CONFIG_SPIRAM_XIP_FROM_PSRAM=n

--- a/Devices/waveshare-s3-lcd-13/device.properties
+++ b/Devices/waveshare-s3-lcd-13/device.properties
@@ -1,27 +1,22 @@
-[general]
-vendor=WaveShare
-name=S3 LCD 1.3"
-incubating=true
+general.vendor=WaveShare
+general.name=S3 LCD 1.3"
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=1.3"
-shape=rectangle
-dpi=261
+display.size=1.3"
+display.shape=rectangle
+display.dpi=261
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact

--- a/Devices/waveshare-s3-touch-lcd-128/device.properties
+++ b/Devices/waveshare-s3-touch-lcd-128/device.properties
@@ -1,33 +1,27 @@
-[general]
-vendor=WaveShare
-name=S3 Touch LCD 1.28"
-incubating=true
+general.vendor=WaveShare
+general.name=S3 Touch LCD 1.28"
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=QUAD
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=QUAD
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=1.28"
-shape=circle
-dpi=265
+display.size=1.28"
+display.shape=circle
+display.dpi=265
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact
 
-[sdkconfig]
 # Fix error "PSRAM space not enough for the Flash instructions" on boot:
-CONFIG_SPIRAM_FETCH_INSTRUCTIONS=n
-CONFIG_SPIRAM_RODATA=n
-CONFIG_SPIRAM_XIP_FROM_PSRAM=n
+sdkconfig.CONFIG_SPIRAM_FETCH_INSTRUCTIONS=n
+sdkconfig.CONFIG_SPIRAM_RODATA=n
+sdkconfig.CONFIG_SPIRAM_XIP_FROM_PSRAM=n

--- a/Devices/waveshare-s3-touch-lcd-147/device.properties
+++ b/Devices/waveshare-s3-touch-lcd-147/device.properties
@@ -1,30 +1,24 @@
-[general]
-vendor=WaveShare
-name=S3 Touch LCD 1.47"
-incubating=true
+general.vendor=WaveShare
+general.name=S3 Touch LCD 1.47"
+general.incubating=true
 
-[apps]
-launcherAppId=Launcher
-autoStartAppId=ApWebServer
+apps.launcherAppId=Launcher
+apps.autoStartAppId=ApWebServer
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=1.47"
-shape=rectangle
-dpi=247
+display.size=1.47"
+display.shape=rectangle
+display.dpi=247
 
-[cdn]
-warningMessage=Touch doesn't work yet
+cdn.warningMessage=Touch doesn't work yet
 
-[lvgl]
-colorDepth=16
-uiDensity=compact
+lvgl.colorDepth=16
+lvgl.uiDensity=compact

--- a/Devices/waveshare-s3-touch-lcd-43/device.properties
+++ b/Devices/waveshare-s3-touch-lcd-43/device.properties
@@ -1,25 +1,20 @@
-[general]
-vendor=WaveShare
-name=S3 Touch LCD 4.3"
+general.vendor=WaveShare
+general.name=S3 Touch LCD 4.3"
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=4MB
-spiRam=true
-spiRamMode=OCT
-spiRamSpeed=120M
-tinyUsb=true
-esptoolFlashFreq=120M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=4MB
+hardware.spiRam=true
+hardware.spiRamMode=OCT
+hardware.spiRamSpeed=120M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=120M
+hardware.bluetooth=true
 
-[display]
-size=4.3"
-shape=rectangle
-dpi=217
+display.size=4.3"
+display.shape=rectangle
+display.dpi=217
 
-[lvgl]
-colorDepth=16
-fontSize=18
+lvgl.colorDepth=16
+lvgl.fontSize=18

--- a/Devices/wireless-tag-wt32-sc01-plus/device.properties
+++ b/Devices/wireless-tag-wt32-sc01-plus/device.properties
@@ -1,24 +1,19 @@
-[general]
-vendor=Wireless Tag
-name=WT32 SC01 Plus
+general.vendor=Wireless Tag
+general.name=WT32 SC01 Plus
 
-[apps]
-launcherAppId=Launcher
+apps.launcherAppId=Launcher
 
-[hardware]
-target=ESP32S3
-flashSize=16MB
-spiRam=true
-spiRamMode=QUAD
-spiRamSpeed=80M
-tinyUsb=true
-esptoolFlashFreq=80M
-bluetooth=true
+hardware.target=ESP32S3
+hardware.flashSize=16MB
+hardware.spiRam=true
+hardware.spiRamMode=QUAD
+hardware.spiRamSpeed=80M
+hardware.tinyUsb=true
+hardware.esptoolFlashFreq=80M
+hardware.bluetooth=true
 
-[display]
-size=3.5"
-shape=rectangle
-dpi=165
+display.size=3.5"
+display.shape=rectangle
+display.dpi=165
 
-[lvgl]
-colorDepth=16
+lvgl.colorDepth=16

--- a/Firmware/CMakeLists.txt
+++ b/Firmware/CMakeLists.txt
@@ -22,7 +22,7 @@ set(DEVICETREE_LOCATION "${PROJECT_ROOT}/Devices/${TACTILITY_DEVICE_ID}")
 # Fixes the sdkconfig bluetooth enable options from getting nuked on non-P4+C6 builds when idf build runs
 if (DEFINED ENV{ESP_IDF_VERSION})
     file(READ "${DEVICETREE_LOCATION}/device.properties" device_properties_content)
-    if (device_properties_content MATCHES "bluetooth=true")
+    if (device_properties_content MATCHES "hardware\\.bluetooth=true")
         list(APPEND REQUIRES_LIST bt)
     endif()
 endif()

--- a/Modules/lvgl-module/CMakeLists.txt
+++ b/Modules/lvgl-module/CMakeLists.txt
@@ -44,7 +44,7 @@ READ_PROPERTIES_TO_MAP(
     device_properties
 )
 # Read UI density
-GET_VALUE_FROM_MAP(device_properties "[lvgl]uiDensity" ui_density)
+GET_VALUE_FROM_MAP(device_properties "lvgl.uiDensity" ui_density)
 # Define UiDensity enum value
 if (ui_density)
     if (ui_density STREQUAL "default")
@@ -52,7 +52,7 @@ if (ui_density)
     elseif (ui_density STREQUAL "compact")
         set(ui_density_variable "LVGL_UI_DENSITY_COMPACT")
     else ()
-        message(FATAL_ERROR "Invalid [lvgl]uiDensity: '${ui_density}'. Must be either 'default' or 'compact'")
+        message(FATAL_ERROR "Invalid lvgl.uiDensity: '${ui_density}'. Must be either 'default' or 'compact'")
     endif ()
     message("UI density set to '${ui_density}' via properties")
 else ()

--- a/Tactility/Private/Tactility/app/AppManifestParsing.h
+++ b/Tactility/Private/Tactility/app/AppManifestParsing.h
@@ -2,13 +2,13 @@
 
 #include <Tactility/app/AppManifest.h>
 
-#include <map>
 #include <string>
 
 namespace tt::app {
 
 bool isValidId(const std::string& id);
 
-bool parseManifest(const std::map<std::string, std::string>& map, AppManifest& manifest);
+/** Parses a manifest.properties file, auto-detecting the V1 (sectioned) or V2 (flat) format from its first line. */
+bool parseManifest(const std::string& filePath, AppManifest& manifest);
 
 }

--- a/Tactility/Private/Tactility/app/AppManifestParsingInternal.h
+++ b/Tactility/Private/Tactility/app/AppManifestParsingInternal.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Tactility/app/AppManifest.h>
+
+#include <map>
+#include <string>
+
+namespace tt::app {
+
+bool getValueFromManifest(const std::map<std::string, std::string>& map, const std::string& key, std::string& output);
+
+bool isValidManifestVersion(const std::string& version);
+bool isValidAppVersionName(const std::string& version);
+bool isValidAppVersionCode(const std::string& version);
+bool isValidName(const std::string& name);
+
+/** Parses a V1 (sectioned INI, e.g. "[app]versionName=...") manifest map. */
+bool parseManifestV1(const std::map<std::string, std::string>& map, AppManifest& manifest);
+
+/** Parses a V2 (flat dot-notation, e.g. "app.version.name=...") manifest map. */
+bool parseManifestV2(const std::map<std::string, std::string>& map, AppManifest& manifest);
+
+}

--- a/Tactility/Source/Tactility.cpp
+++ b/Tactility/Source/Tactility.cpp
@@ -3,7 +3,6 @@
 #endif
 
 #include <format>
-#include <map>
 
 #include <Tactility/Tactility.h>
 #include <Tactility/TactilityConfig.h>
@@ -17,7 +16,6 @@
 #include <Tactility/app/AppRegistration.h>
 #include <Tactility/file/File.h>
 #include <Tactility/file/FileLock.h>
-#include <Tactility/file/PropertiesFile.h>
 #include <Tactility/hal/HalPrivate.h>
 #include <Tactility/lvgl/LvglPrivate.h>
 #include <Tactility/network/NtpPrivate.h>
@@ -216,14 +214,8 @@ static void registerInstalledApp(std::string path) {
         return;
     }
 
-    std::map<std::string, std::string> properties;
-    if (!file::loadPropertiesFile(manifest_path, properties)) {
-        LOGGER.error("Failed to load manifest at {}", manifest_path);
-        return;
-    }
-
     app::AppManifest manifest;
-    if (!app::parseManifest(properties, manifest)) {
+    if (!app::parseManifest(manifest_path, manifest)) {
         LOGGER.error("Failed to parse manifest at {}", manifest_path);
         return;
     }

--- a/Tactility/Source/app/AppInstall.cpp
+++ b/Tactility/Source/app/AppInstall.cpp
@@ -4,7 +4,6 @@
 #include <Tactility/app/AppRegistration.h>
 #include <Tactility/file/File.h>
 #include <Tactility/file/FileLock.h>
-#include <Tactility/file/PropertiesFile.h>
 #include <tactility/hal/Device.h>
 #include <Tactility/Logger.h>
 #include <Tactility/Paths.h>
@@ -138,15 +137,8 @@ bool install(const std::string& path) {
         return false;
     }
 
-    std::map<std::string, std::string> properties;
-    if (!file::loadPropertiesFile(manifest_path, properties)) {
-        LOGGER.error("Failed to load manifest at {}", manifest_path);
-        cleanupInstallDirectory(app_target_path);
-        return false;
-    }
-
     AppManifest manifest;
-    if (!parseManifest(properties, manifest)) {
+    if (!parseManifest(manifest_path, manifest)) {
         LOGGER.warn("Invalid manifest");
         cleanupInstallDirectory(app_target_path);
         return false;

--- a/Tactility/Source/app/AppManifestParsing.cpp
+++ b/Tactility/Source/app/AppManifestParsing.cpp
@@ -1,8 +1,12 @@
 #include <Tactility/app/AppManifestParsing.h>
+#include <Tactility/app/AppManifestParsingInternal.h>
 
 #include <Tactility/Logger.h>
+#include <Tactility/StringUtils.h>
+#include <Tactility/file/File.h>
+#include <Tactility/file/PropertiesFile.h>
+
 #include <algorithm>
-#include <regex>
 
 namespace tt::app {
 
@@ -12,7 +16,7 @@ constexpr bool validateString(const std::string& value, const std::function<bool
     return std::ranges::all_of(value, isValidChar);
 }
 
-static bool getValueFromManifest(const std::map<std::string, std::string>& map, const std::string& key, std::string& output) {
+bool getValueFromManifest(const std::map<std::string, std::string>& map, const std::string& key, std::string& output) {
     const auto iterator = map.find(key);
     if (iterator == map.end()) {
         LOGGER.error("Failed to find {} in manifest", key);
@@ -28,97 +32,61 @@ bool isValidId(const std::string& id) {
     });
 }
 
-static bool isValidManifestVersion(const std::string& version) {
+bool isValidManifestVersion(const std::string& version) {
     return !version.empty() && validateString(version, [](const char c) {
         return std::isalnum(c) != 0 || c == '.';
     });
 }
 
-static bool isValidAppVersionName(const std::string& version) {
+bool isValidAppVersionName(const std::string& version) {
     return !version.empty() && validateString(version, [](const char c) {
         return std::isalnum(c) != 0 || c == '.' || c == '-' || c == '_';
     });
 }
 
-static bool isValidAppVersionCode(const std::string& version) {
+bool isValidAppVersionCode(const std::string& version) {
     return !version.empty() && validateString(version, [](const char c) {
         return std::isdigit(c) != 0;
     });
 }
 
-static bool isValidName(const std::string& name) {
+bool isValidName(const std::string& name) {
     return name.size() >= 2 && validateString(name, [](const char c) {
         return std::isalnum(c) != 0 || c == ' ' || c == '-';
     });
 }
 
-bool parseManifest(const std::map<std::string, std::string>& map, AppManifest& manifest) {
-    LOGGER.info("Parsing manifest");
+/** The V1 format's first line is always the literal "[manifest]" section header; V2 files are flat from the first line onward. */
+static bool detectIsV1Format(const std::string& filePath) {
+    std::string first_line;
+    bool got_first_line = false;
+    file::readLines(filePath, true, [&first_line, &got_first_line](const char* line) {
+        if (!got_first_line) {
+            first_line = string::trim(std::string(line), " \t\r\n");
+            got_first_line = true;
+        }
+    });
+    return first_line == "[manifest]";
+}
 
-    // [manifest]
+bool parseManifest(const std::string& filePath, AppManifest& manifest) {
+    LOGGER.info("Parsing manifest {}", filePath);
 
-    std::string manifest_version;
-    if (!getValueFromManifest(map, "[manifest]version", manifest_version)) {
+    bool is_v1_format = detectIsV1Format(filePath);
+
+    std::map<std::string, std::string> properties;
+    if (!file::loadPropertiesFile(filePath, properties)) {
+        LOGGER.error("Failed to load manifest at {}", filePath);
         return false;
     }
 
-    if (!isValidManifestVersion(manifest_version)) {
-        LOGGER.error("Invalid version");
+    bool success = is_v1_format
+        ? parseManifestV1(properties, manifest)
+        : parseManifestV2(properties, manifest);
+
+    if (!success) {
         return false;
     }
-
-    // [app]
-
-    if (!getValueFromManifest(map, "[app]id", manifest.appId)) {
-        return false;
-    }
-
-    if (!isValidId(manifest.appId)) {
-        LOGGER.error("Invalid app id");
-        return false;
-    }
-
-    if (!getValueFromManifest(map, "[app]name", manifest.appName)) {
-        return false;
-    }
-
-    if (!isValidName(manifest.appName)) {
-        LOGGER.error("Invalid app name");
-        return false;
-    }
-
-    if (!getValueFromManifest(map, "[app]versionName", manifest.appVersionName)) {
-        return false;
-    }
-
-    if (!isValidAppVersionName(manifest.appVersionName)) {
-        LOGGER.error("Invalid app version name");
-        return false;
-    }
-
-    std::string version_code_string;
-    if (!getValueFromManifest(map, "[app]versionCode", version_code_string)) {
-        return false;
-    }
-
-    if (!isValidAppVersionCode(version_code_string)) {
-        LOGGER.error("Invalid app version code");
-        return false;
-    }
-
-    manifest.appVersionCode = std::stoull(version_code_string);
-
-    // [target]
-
-    if (!getValueFromManifest(map, "[target]sdk", manifest.targetSdk)) {
-        return false;
-    }
-
-    if (!getValueFromManifest(map, "[target]platforms", manifest.targetPlatforms)) {
-        return false;
-    }
-
-    // Defaults
 
     manifest.appCategory = Category::User;
     manifest.appLocation = Location::external("");

--- a/Tactility/Source/app/AppManifestParsingV1.cpp
+++ b/Tactility/Source/app/AppManifestParsingV1.cpp
@@ -1,0 +1,77 @@
+#include <Tactility/app/AppManifestParsing.h>
+#include <Tactility/app/AppManifestParsingInternal.h>
+
+#include <Tactility/Logger.h>
+
+namespace tt::app {
+
+static const auto LOGGER = Logger("AppManifestV1");
+
+bool parseManifestV1(const std::map<std::string, std::string>& map, AppManifest& manifest) {
+    // [manifest]
+
+    std::string manifest_version;
+    if (!getValueFromManifest(map, "[manifest]version", manifest_version)) {
+        return false;
+    }
+
+    if (!isValidManifestVersion(manifest_version)) {
+        LOGGER.error("Invalid version");
+        return false;
+    }
+
+    // [app]
+
+    if (!getValueFromManifest(map, "[app]id", manifest.appId)) {
+        return false;
+    }
+
+    if (!isValidId(manifest.appId)) {
+        LOGGER.error("Invalid app id");
+        return false;
+    }
+
+    if (!getValueFromManifest(map, "[app]name", manifest.appName)) {
+        return false;
+    }
+
+    if (!isValidName(manifest.appName)) {
+        LOGGER.error("Invalid app name");
+        return false;
+    }
+
+    if (!getValueFromManifest(map, "[app]versionName", manifest.appVersionName)) {
+        return false;
+    }
+
+    if (!isValidAppVersionName(manifest.appVersionName)) {
+        LOGGER.error("Invalid app version name");
+        return false;
+    }
+
+    std::string version_code_string;
+    if (!getValueFromManifest(map, "[app]versionCode", version_code_string)) {
+        return false;
+    }
+
+    if (!isValidAppVersionCode(version_code_string)) {
+        LOGGER.error("Invalid app version code");
+        return false;
+    }
+
+    manifest.appVersionCode = std::stoull(version_code_string);
+
+    // [target]
+
+    if (!getValueFromManifest(map, "[target]sdk", manifest.targetSdk)) {
+        return false;
+    }
+
+    if (!getValueFromManifest(map, "[target]platforms", manifest.targetPlatforms)) {
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/Tactility/Source/app/AppManifestParsingV2.cpp
+++ b/Tactility/Source/app/AppManifestParsingV2.cpp
@@ -1,0 +1,77 @@
+#include <Tactility/app/AppManifestParsing.h>
+#include <Tactility/app/AppManifestParsingInternal.h>
+
+#include <Tactility/Logger.h>
+
+namespace tt::app {
+
+static const auto LOGGER = Logger("AppManifestV2");
+
+bool parseManifestV2(const std::map<std::string, std::string>& map, AppManifest& manifest) {
+    // manifest
+
+    std::string manifest_version;
+    if (!getValueFromManifest(map, "manifest.version", manifest_version)) {
+        return false;
+    }
+
+    if (!isValidManifestVersion(manifest_version)) {
+        LOGGER.error("Invalid version");
+        return false;
+    }
+
+    // app
+
+    if (!getValueFromManifest(map, "app.id", manifest.appId)) {
+        return false;
+    }
+
+    if (!isValidId(manifest.appId)) {
+        LOGGER.error("Invalid app id");
+        return false;
+    }
+
+    if (!getValueFromManifest(map, "app.name", manifest.appName)) {
+        return false;
+    }
+
+    if (!isValidName(manifest.appName)) {
+        LOGGER.error("Invalid app name");
+        return false;
+    }
+
+    if (!getValueFromManifest(map, "app.version.name", manifest.appVersionName)) {
+        return false;
+    }
+
+    if (!isValidAppVersionName(manifest.appVersionName)) {
+        LOGGER.error("Invalid app version name");
+        return false;
+    }
+
+    std::string version_code_string;
+    if (!getValueFromManifest(map, "app.version.code", version_code_string)) {
+        return false;
+    }
+
+    if (!isValidAppVersionCode(version_code_string)) {
+        LOGGER.error("Invalid app version code");
+        return false;
+    }
+
+    manifest.appVersionCode = std::stoull(version_code_string);
+
+    // target
+
+    if (!getValueFromManifest(map, "target.sdk", manifest.targetSdk)) {
+        return false;
+    }
+
+    if (!getValueFromManifest(map, "target.platforms", manifest.targetPlatforms)) {
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/Tests/SdkIntegration/manifest.properties
+++ b/Tests/SdkIntegration/manifest.properties
@@ -1,10 +1,7 @@
-[manifest]
-version=0.1
-[target]
-sdk=0.0.0
-platforms=esp32,esp32s3,esp32c6,esp32p4
-[app]
-id=one.tactility.sdktest
-versionName=0.1.0
-versionCode=1
-name=SDK Test
+manifest.version=0.2
+target.sdk=0.0.0
+target.platforms=esp32,esp32s3,esp32c6,esp32p4
+app.id=one.tactility.sdktest
+app.version.name=0.1.0
+app.version.code=1
+app.name=SDK Test

--- a/Tests/SdkIntegration/tactility.py
+++ b/Tests/SdkIntegration/tactility.py
@@ -1,4 +1,3 @@
-import configparser
 import json
 import os
 import re
@@ -13,7 +12,7 @@ import tarfile
 from urllib.parse import urlparse
 
 ttbuild_path = ".tactility"
-ttbuild_version = "3.3.0"
+ttbuild_version = "4.0.0"
 ttbuild_cdn = "https://cdn.tactilityproject.org"
 ttbuild_sdk_json_validity = 3600  # seconds
 ttport = 6666
@@ -30,10 +29,10 @@ shell_color_cyan = "\033[36m"
 shell_color_reset = "\033[m"
 
 def print_help():
-    print("Usage: python tactility.py [action] [options]")
+    print("Usage: python tactility.py [app_path] [action] [options]")
     print("")
     print("Actions:")
-    print("  build [platform]              Build the app. Optionally specify a platform.")
+    print("  build [platform]               Build the app. Optionally specify a platform.")
     print("    Supported platforms are lower case. Example: esp32s3")
     print("    Supported platforms are read from manifest.properties")
     print("  clean                          Clean the build folders")
@@ -50,6 +49,10 @@ def print_help():
     print("  --local-sdk                    Use SDK specified by environment variable TACTILITY_SDK_PATH with platform subfolders matching target platforms.")
     print("  --skip-build                   Run everything except the idf.py/CMake commands")
     print("  --verbose                      Show extra console output")
+    print("")
+    print("Examples:")
+    print("  python tactility.py Apps/Snake build esp32s3 --verbose")
+    print("  python tactility.py Apps/Snake bir 192.168.1.50 esp32s3")
 
 # region Core
 
@@ -102,9 +105,17 @@ def get_url(ip, path):
     return f"http://{ip}:{ttport}{path}"
 
 def read_properties_file(path):
-    config = configparser.RawConfigParser()
-    config.read(path)
-    return config
+    properties = {}
+    with open(path, "r") as file:
+        for line in file:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            key, sep, value = line.partition("=")
+            if not sep:
+                continue
+            properties[key.strip()] = value.strip()
+    return properties
 
 #endregion Core
 
@@ -227,32 +238,12 @@ def read_manifest():
     return read_properties_file("manifest.properties")
 
 def validate_manifest(manifest):
-    # [manifest]
-    if not "manifest" in manifest:
-        exit_with_error("Invalid manifest format: [manifest] not found")
-    if not "version" in manifest["manifest"]:
-        exit_with_error("Invalid manifest format: [manifest] version not found")
-    # [target]
-    if not "target" in manifest:
-        exit_with_error("Invalid manifest format: [target] not found")
-    if not "sdk" in manifest["target"]:
-        exit_with_error("Invalid manifest format: [target] sdk not found")
-    if not "platforms" in manifest["target"]:
-        exit_with_error("Invalid manifest format: [target] platforms not found")
-    # [app]
-    if not "app" in manifest:
-        exit_with_error("Invalid manifest format: [app] not found")
-    if not "id" in manifest["app"]:
-        exit_with_error("Invalid manifest format: [app] id not found")
-    if not "versionName" in manifest["app"]:
-        exit_with_error("Invalid manifest format: [app] versionName not found")
-    if not "versionCode" in manifest["app"]:
-        exit_with_error("Invalid manifest format: [app] versionCode not found")
-    if not "name" in manifest["app"]:
-        exit_with_error("Invalid manifest format: [app] name not found")
+    for key in ("manifest.version", "target.sdk", "target.platforms", "app.id", "app.version.name", "app.version.code", "app.name"):
+        if key not in manifest:
+            exit_with_error(f"Invalid manifest format: {key} not found")
 
 def is_valid_manifest_platform(manifest, platform):
-    manifest_platforms = manifest["target"]["platforms"].split(",")
+    manifest_platforms = manifest["target.platforms"].split(",")
     return platform in manifest_platforms
 
 def validate_manifest_platform(manifest, platform):
@@ -261,7 +252,7 @@ def validate_manifest_platform(manifest, platform):
 
 def get_manifest_target_platforms(manifest, requested_platform):
     if requested_platform == "" or requested_platform is None:
-        return manifest["target"]["platforms"].split(",")
+        return manifest["target.platforms"].split(",")
     else:
         validate_manifest_platform(manifest, requested_platform)
         return [requested_platform]
@@ -422,7 +413,7 @@ def build_consecutively(version, platform, skip_build):
     shell_needed = sys.platform == "win32"
     build_command = ["idf.py", "-B", cmake_path, "elf"]
     if verbose:
-        print(f"Running command: {" ".join(build_command)}")
+        print(f"Running command: {' '.join(build_command)}")
     with subprocess.Popen(build_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=shell_needed) as process:
         build_output = wait_for_process(process)
         if process.returncode == 0:
@@ -451,7 +442,7 @@ def package_intermediate_binaries(target_path, platforms):
     for platform in platforms:
         elf_path = find_elf_file(platform)
         if elf_path is None:
-            print_error(f"ELF file not found at {elf_path}")
+            print_error(f"ELF file not found for {platform}")
             return False
         shutil.copy(elf_path, os.path.join(elf_dir, f"{platform}.elf"))
     return True
@@ -486,9 +477,8 @@ def package_all(platforms):
     # Create build/something.app
     try:
         tar_path = package_name(platforms)
-        tar = tarfile.open(tar_path, mode="w", format=tarfile.USTAR_FORMAT)
-        tar.add(os.path.join("build", "package-intermediate"), arcname="")
-        tar.close()
+        with tarfile.open(tar_path, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+            tar.add(os.path.join("build", "package-intermediate"), arcname="")
         print_status_success(status)
         return True
     except Exception as e:
@@ -509,7 +499,7 @@ def build_action(manifest, platform_arg, skip_build):
     if use_local_sdk:
         global local_base_path
         local_base_path = os.environ.get("TACTILITY_SDK_PATH")
-        validate_local_sdks(platforms_to_build, manifest["target"]["sdk"])
+        validate_local_sdks(platforms_to_build, manifest["target.sdk"])
     
     if should_fetch_sdkconfig_files(platforms_to_build):
         fetch_sdkconfig_files(platforms_to_build)
@@ -518,7 +508,7 @@ def build_action(manifest, platform_arg, skip_build):
         sdk_json = read_sdk_json()
         validate_self(sdk_json)
     # Build
-    sdk_version = manifest["target"]["sdk"]
+    sdk_version = manifest["target.sdk"]
     if not use_local_sdk:
         if not sdk_download_all(sdk_version, platforms_to_build):
             exit_with_error("Failed to download one or more SDKs")
@@ -567,7 +557,7 @@ def get_device_info(ip):
         print_status_error(f"Device info request failed: {e}")
 
 def run_action(manifest, ip):
-    app_id = manifest["app"]["id"]
+    app_id = manifest["app.id"]
     print_status_busy("Running")
     url = get_url(ip, "/app/run")
     params = {'id': app_id}
@@ -611,7 +601,7 @@ def install_action(ip, platforms):
         return False
 
 def uninstall_action(manifest, ip):
-    app_id = manifest["app"]["id"]
+    app_id = manifest["app.id"]
     print_status_busy("Uninstalling")
     url = get_url(ip, "/app/uninstall")
     params = {'id': app_id}
@@ -645,6 +635,20 @@ if __name__ == "__main__":
     if "--local-sdk" in sys.argv:
         use_local_sdk = True
         sys.argv.remove("--local-sdk")
+    
+    # Check if the first argument is a path to an app directory
+    if len(sys.argv) > 2:
+        potential_app_dir = sys.argv[1]
+        if os.path.isdir(potential_app_dir) and os.path.isfile(os.path.join(potential_app_dir, "manifest.properties")):
+            if verbose:
+                print_status_success(f"Switching to app directory: {potential_app_dir}")
+            os.chdir(potential_app_dir)
+            sys.argv = [sys.argv[0]] + sys.argv[2:]
+    
+    if len(sys.argv) < 2:
+        print_help()
+        sys.exit(1)
+    
     action_arg = sys.argv[1]
 
     # Environment setup
@@ -653,7 +657,7 @@ if __name__ == "__main__":
         exit_with_error("manifest.properties not found")
     manifest = read_manifest()
     validate_manifest(manifest)
-    all_platform_targets = manifest["target"]["platforms"].split(",")
+    all_platform_targets = manifest["target.platforms"].split(",")
     # Update SDK cache (tool.json)
     if not use_local_sdk and should_update_tool_json() and not update_tool_json():
         exit_with_error("Failed to retrieve SDK info")

--- a/Tests/Tactility/Source/AppManifestParsingTest.cpp
+++ b/Tests/Tactility/Source/AppManifestParsingTest.cpp
@@ -1,0 +1,83 @@
+#include "../../TactilityCore/Source/TestFile.h"
+#include "../../Tactility/Private/Tactility/app/AppManifestParsing.h"
+#include "../../Tactility/Private/Tactility/app/AppManifestParsingInternal.h"
+
+#include "doctest.h"
+
+using namespace tt;
+using namespace tt::app;
+
+TEST_CASE("parseManifest() should parse a V1 (sectioned) manifest.properties file") {
+    TestFile file("test-manifest-v1.properties");
+    file.writeData(
+        "[manifest]\n"
+        "version=0.1\n"
+        "[target]\n"
+        "sdk=0.0.0\n"
+        "platforms=esp32,esp32s3,esp32c6,esp32p4\n"
+        "[app]\n"
+        "id=one.tactility.sdktest\n"
+        "versionName=0.1.0\n"
+        "versionCode=1\n"
+        "name=SDK Test\n"
+    );
+
+    AppManifest manifest;
+    CHECK_EQ(parseManifest(file.getPath(), manifest), true);
+    CHECK_EQ(manifest.targetSdk, "0.0.0");
+    CHECK_EQ(manifest.targetPlatforms, "esp32,esp32s3,esp32c6,esp32p4");
+    CHECK_EQ(manifest.appId, "one.tactility.sdktest");
+    CHECK_EQ(manifest.appName, "SDK Test");
+    CHECK_EQ(manifest.appVersionName, "0.1.0");
+    CHECK_EQ(manifest.appVersionCode, 1);
+}
+
+TEST_CASE("parseManifest() should parse a V2 (flat) manifest.properties file") {
+    TestFile file("test-manifest-v2.properties");
+    file.writeData(
+        "manifest.version=0.1\n"
+        "target.sdk=0.0.0\n"
+        "target.platforms=esp32,esp32s3,esp32c6,esp32p4\n"
+        "app.id=one.tactility.sdktest\n"
+        "app.version.name=0.1.0\n"
+        "app.version.code=1\n"
+        "app.name=SDK Test\n"
+    );
+
+    AppManifest manifest;
+    CHECK_EQ(parseManifest(file.getPath(), manifest), true);
+    CHECK_EQ(manifest.targetSdk, "0.0.0");
+    CHECK_EQ(manifest.targetPlatforms, "esp32,esp32s3,esp32c6,esp32p4");
+    CHECK_EQ(manifest.appId, "one.tactility.sdktest");
+    CHECK_EQ(manifest.appName, "SDK Test");
+    CHECK_EQ(manifest.appVersionName, "0.1.0");
+    CHECK_EQ(manifest.appVersionCode, 1);
+}
+
+TEST_CASE("parseManifestV1() should fail when a required key is missing") {
+    std::map<std::string, std::string> properties = {
+        {"[manifest]version", "0.1"},
+        {"[app]id", "one.tactility.sdktest"},
+        {"[app]name", "SDK Test"},
+        {"[app]versionName", "0.1.0"},
+        {"[app]versionCode", "1"},
+        // Missing [target]sdk
+        {"[target]platforms", "esp32"},
+    };
+    AppManifest manifest;
+    CHECK_EQ(parseManifestV1(properties, manifest), false);
+}
+
+TEST_CASE("parseManifestV2() should fail when the app id is invalid") {
+    std::map<std::string, std::string> properties = {
+        {"manifest.version", "0.1"},
+        {"app.id", "abc"}, // too short (isValidId requires >= 5 chars)
+        {"app.name", "SDK Test"},
+        {"app.version.name", "0.1.0"},
+        {"app.version.code", "1"},
+        {"target.sdk", "0.0.0"},
+        {"target.platforms", "esp32"},
+    };
+    AppManifest manifest;
+    CHECK_EQ(parseManifestV2(properties, manifest), false);
+}

--- a/device.py
+++ b/device.py
@@ -1,9 +1,7 @@
-import configparser
 import glob
 import os
 import shutil
 import sys
-from configparser import ConfigParser
 
 if sys.platform == "win32":
     SHELL_COLOR_RED = ""
@@ -42,11 +40,17 @@ def read_file(path: str):
         return result
 
 def read_properties_file(path):
-    config = configparser.RawConfigParser()
-    # Don't convert keys to lowercase
-    config.optionxform = str
-    config.read(path)
-    return config
+    properties = {}
+    with open(path, "r") as file:
+        for line in file:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            key, sep, value = line.partition("=")
+            if not sep:
+                continue
+            properties[key.strip()] = value.strip()
+    return properties
 
 def read_device_properties(device_id):
     device_file_path = get_properties_file_path(device_id)
@@ -54,32 +58,24 @@ def read_device_properties(device_id):
         exit_with_error(f"Device file not found: {device_file_path}")
     return read_properties_file(device_file_path)
 
-def has_group(properties: ConfigParser, group: str):
-    return group in properties.sections()
+def has_group(properties: dict, group: str):
+    prefix = f"{group}."
+    return any(key.startswith(prefix) for key in properties)
 
-def get_property_or_exit(properties: ConfigParser, group: str, key: str):
-    if group not in properties.sections():
-        exit_with_error(f"Device properties does not contain group: {group}")
-    if key not in properties[group].keys():
-        exit_with_error(f"Device properties does not contain key: {key}")
-    return properties[group][key]
+def get_property_or_exit(properties: dict, group: str, key: str):
+    full_key = f"{group}.{key}"
+    if full_key not in properties:
+        exit_with_error(f"Device properties does not contain key: {full_key}")
+    return properties[full_key]
 
-def get_property_or_default(properties: ConfigParser, group: str, key: str, default):
-    if group not in properties.sections():
-        return default
-    if key not in properties[group].keys():
-        return default
-    return properties[group][key]
+def get_property_or_default(properties: dict, group: str, key: str, default):
+    return properties.get(f"{group}.{key}", default)
 
-def get_property_or_none(properties: ConfigParser, group: str, key: str):
+def get_property_or_none(properties: dict, group: str, key: str):
     return get_property_or_default(properties, group, key, None)
 
-def get_boolean_property_or_false(properties: ConfigParser, group: str, key: str):
-    if group not in properties.sections():
-        return False
-    if key not in properties[group].keys():
-        return False
-    return properties[group][key] == "true"
+def get_boolean_property_or_false(properties: dict, group: str, key: str):
+    return properties.get(f"{group}.{key}") == "true"
 
 def safe_int(value: str, error_message: str):
     try:
@@ -98,7 +94,7 @@ def write_defaults(output_file):
     default_properties = read_file(default_properties_path)
     output_file.write(default_properties)
 
-def write_partition_table(output_file, device_properties: ConfigParser, is_dev: bool):
+def write_partition_table(output_file, device_properties: dict, is_dev: bool):
     if is_dev:
         flash_size_number = 4
     else:
@@ -111,7 +107,7 @@ def write_partition_table(output_file, device_properties: ConfigParser, is_dev: 
     output_file.write(f"CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions-{flash_size_number}mb.csv\"\n")
     output_file.write(f"CONFIG_PARTITION_TABLE_FILENAME=\"partitions-{flash_size_number}mb.csv\"\n")
 
-def write_tactility_variables(output_file, device_properties: ConfigParser, device_id: str):
+def write_tactility_variables(output_file, device_properties: dict, device_id: str):
     # Board and vendor
     board_vendor = get_property_or_exit(device_properties, "general", "vendor").replace("\"", "\\\"")
     board_name = get_property_or_exit(device_properties, "general", "name").replace("\"", "\\\"")
@@ -133,7 +129,7 @@ def write_tactility_variables(output_file, device_properties: ConfigParser, devi
         safe_auto_start_app_id = auto_start_app_id.replace("\"", "\\\"")
         output_file.write(f"CONFIG_TT_AUTO_START_APP_ID=\"{safe_auto_start_app_id}\"\n")
 
-def write_core_variables(output_file, device_properties: ConfigParser):
+def write_core_variables(output_file, device_properties: dict):
     idf_target = get_property_or_exit(device_properties, "hardware", "target").lower()
     output_file.write("# Target\n")
     output_file.write(f"CONFIG_IDF_TARGET=\"{idf_target}\"\n")
@@ -157,7 +153,7 @@ def write_core_variables(output_file, device_properties: ConfigParser):
         output_file.write("CONFIG_HEAP_PLACE_FUNCTION_INTO_FLASH=y\n")
         output_file.write("CONFIG_RINGBUF_PLACE_ISR_FUNCTIONS_INTO_FLASH=y\n")
 
-def write_flash_variables(output_file, device_properties: ConfigParser):
+def write_flash_variables(output_file, device_properties: dict):
     flash_size = get_property_or_exit(device_properties, "hardware", "flashSize")
     if not flash_size.endswith("MB"):
         exit_with_error("Flash size should be written as xMB or xxMB (e.g. 4MB, 16MB)")
@@ -170,7 +166,7 @@ def write_flash_variables(output_file, device_properties: ConfigParser):
     if esptool_flash_freq is not None:
         output_file.write(f"CONFIG_ESPTOOLPY_FLASHFREQ_{esptool_flash_freq}=y\n")
 
-def write_spiram_variables(output_file, device_properties: ConfigParser):
+def write_spiram_variables(output_file, device_properties: dict):
     idf_target = get_property_or_exit(device_properties, "hardware", "target").lower()
     has_spiram = get_property_or_exit(device_properties, "hardware", "spiRam")
     if has_spiram != "true":
@@ -202,7 +198,7 @@ def write_spiram_variables(output_file, device_properties: ConfigParser):
         output_file.write("CONFIG_SPIRAM_RODATA=y\n")
         output_file.write("CONFIG_SPIRAM_XIP_FROM_PSRAM=y\n")
 
-def write_performance_improvements(output_file, device_properties: ConfigParser):
+def write_performance_improvements(output_file, device_properties: dict):
     idf_target = get_property_or_exit(device_properties, "hardware", "target").lower()
     if idf_target == "esp32s3":
         output_file.write("# Performance improvement: Fixes glitches in the RGB display driver when rendering new screens/apps\n")
@@ -220,7 +216,7 @@ def write_lvgl_variable_placeholders(output_file):
     output_file.write("CONFIG_TT_LVGL_LAUNCHER_ICON_SIZE=30\n")
     output_file.write("CONFIG_TT_LVGL_SHARED_ICON_SIZE=12\n")
 
-def write_lvgl_variables(output_file, device_properties: ConfigParser):
+def write_lvgl_variables(output_file, device_properties: dict):
     output_file.write("# LVGL\n")
     if not has_group(device_properties, "lvgl") or not has_group(device_properties, "display"):
         write_lvgl_variable_placeholders(output_file)
@@ -314,7 +310,7 @@ def write_lvgl_variables(output_file, device_properties: ConfigParser):
         output_file.write("CONFIG_TT_LVGL_SHARED_ICON_SIZE=32\n")
 
 
-def write_usb_variables(output_file, device_properties: ConfigParser):
+def write_usb_variables(output_file, device_properties: dict):
     has_tiny_usb = get_boolean_property_or_false(device_properties, "hardware", "tinyUsb")
     if has_tiny_usb:
         output_file.write("# TinyUSB\n")
@@ -328,7 +324,7 @@ def write_usb_variables(output_file, device_properties: ConfigParser):
             # the FS/FSLS controller (USB-C OTG on Tab5), avoiding the conflict.
             output_file.write("CONFIG_TINYUSB_RHPORT_FS=y\n")
 
-def write_bluetooth_variables(output_file, device_properties: ConfigParser):
+def write_bluetooth_variables(output_file, device_properties: dict):
     idf_target = get_property_or_exit(device_properties, "hardware", "target").lower()
     has_bluetooth = get_boolean_property_or_false(device_properties, "hardware", "bluetooth")
     if has_bluetooth:
@@ -361,7 +357,7 @@ def write_bluetooth_variables(output_file, device_properties: ConfigParser):
         # rapid connect/disconnect/re-pair loop.
         output_file.write("CONFIG_BT_NIMBLE_NVS_PERSIST=y\n")
 
-def write_usbhost_variables(output_file, device_properties: ConfigParser):
+def write_usbhost_variables(output_file, device_properties: dict):
     has_usbhost = get_boolean_property_or_false(device_properties, "hardware", "usbHostEnabled")
     if has_usbhost:
         output_file.write("# USB Host\n")
@@ -373,15 +369,16 @@ def write_usbhost_variables(output_file, device_properties: ConfigParser):
         output_file.write("CONFIG_USB_HOST_RESET_RECOVERY_MS=100\n")
         output_file.write("CONFIG_USB_HOST_SET_ADDR_RECOVERY_MS=500\n")
 
-def write_custom_sdkconfig(output_file, device_properties: ConfigParser):
-    if "sdkconfig" in device_properties.sections():
+def write_custom_sdkconfig(output_file, device_properties: dict):
+    prefix = "sdkconfig."
+    sdkconfig_items = [(key[len(prefix):], value) for key, value in device_properties.items() if key.startswith(prefix)]
+    if sdkconfig_items:
         output_file.write("# Custom\n")
-        section = device_properties["sdkconfig"]
-        for key in section.keys():
-            value = section[key].replace("\"", "\\\"")
-            output_file.write(f"{key}={value}\n")
+        for key, value in sdkconfig_items:
+            escaped_value = value.replace("\"", "\\\"")
+            output_file.write(f"{key}={escaped_value}\n")
 
-def write_properties(output_file, device_properties: ConfigParser, device_id: str, is_dev: bool):
+def write_properties(output_file, device_properties: dict, device_id: str, is_dev: bool):
     write_defaults(output_file)
     output_file.write("\n\n")
     write_tactility_variables(output_file, device_properties, device_id)


### PR DESCRIPTION
We used to parse the properties files as if they were ini files. That's corrected now.
Device properties are all updated.
App manifest supports old and new format for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device and app configuration files now support a flat `key=value` format with dotted namespaces.
  * App manifests can be read in both the older sectioned format and the newer flattened format (manifest version updated accordingly).

* **Bug Fixes**
  * Improved property parsing to consistently ignore blank lines and comments.
  * Updated Bluetooth detection and LVGL UI density reading to use the new property keys.

* **Tests**
  * Added tests covering both manifest formats and validation failures, plus updated integration tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->