### PR TITLE
Implement SD card for WaveShare S3 Touch LCD 4.3"

### DIFF
--- a/Devices/waveshare-s3-touch-lcd-43/Source/Configuration.cpp
+++ b/Devices/waveshare-s3-touch-lcd-43/Source/Configuration.cpp
@@ -2,7 +2,21 @@
 
 #include <Tactility/hal/Configuration.h>
 
+#include <tactility/drivers/i2c_controller.h>
+
 using namespace tt::hal;
+
+static bool init() {
+    auto* i2c = device_find_by_name("i2c0");
+    check(i2c);
+
+    uint8_t write_buf = 0x01;
+    i2c_controller_write(i2c, 0x24, &write_buf, 1, 200 / portTICK_PERIOD_MS);
+    write_buf = 0x0E; // Pin 2, 3 and 4 high, pin 1 and 5 low
+    i2c_controller_write(i2c, 0x38, &write_buf, 1, 200 / portTICK_PERIOD_MS);
+
+    return true;
+}
 
 static DeviceVector createDevices() {
     return {
@@ -11,5 +25,6 @@ static DeviceVector createDevices() {
 }
 
 extern const Configuration hardwareConfiguration = {
+    .initBoot = init,
     .createDevices = createDevices
 };

--- a/Devices/waveshare-s3-touch-lcd-43/Source/module.cpp
+++ b/Devices/waveshare-s3-touch-lcd-43/Source/module.cpp
@@ -12,7 +12,7 @@ static error_t stop() {
     return ERROR_NONE;
 }
 
-struct Module waveshare_s3_touch_lcd_43_module = {
+Module waveshare_s3_touch_lcd_43_module = {
     .name = "waveshare-s3-touch-lcd-43",
     .start = start,
     .stop = stop,

--- a/Devices/waveshare-s3-touch-lcd-43/device.properties
+++ b/Devices/waveshare-s3-touch-lcd-43/device.properties
@@ -13,7 +13,7 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-storage.userDataLocation=Internal
+storage.userDataLocation=SD
 
 display.size=4.3"
 display.shape=rectangle

--- a/Devices/waveshare-s3-touch-lcd-43/waveshare,s3-touch-lcd-43.dts
+++ b/Devices/waveshare-s3-touch-lcd-43/waveshare,s3-touch-lcd-43.dts
@@ -26,8 +26,8 @@
 		compatible = "espressif,esp32-i2c";
 		port = <I2C_NUM_0>;
 		clock-frequency = <400000>;
-		pin-sda = <&gpio0 8 GPIO_FLAG_NONE>;
-		pin-scl = <&gpio0 9 GPIO_FLAG_NONE>;
+		pin-sda = <&gpio0 8 GPIO_FLAG_PULL_UP>;
+		pin-scl = <&gpio0 9 GPIO_FLAG_PULL_UP>;
 	};
 
 	spi0 {
@@ -37,7 +37,7 @@
 		pin-mosi = <&gpio0 11 GPIO_FLAG_NONE>;
 		pin-miso = <&gpio0 13 GPIO_FLAG_NONE>;
 		pin-sclk = <&gpio0 12 GPIO_FLAG_NONE>;
-	
+
 		sdcard@0 {
 			compatible = "espressif,esp32-sdspi";
 			frequency-khz = <20000>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boot-time hardware setup for the device, including initial I2C initialization.

* **Bug Fixes**
  * Enabled pull-up behavior on the I2C data and clock lines for more reliable communication.
  * Changed user data storage to the SD card instead of internal storage.

* **Refactor**
  * Updated module registration details without changing startup or shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->