### PR TITLE
Fix test build: stale TestFile.h includes after #550 + hardcoded g++ in test CMakeLists

### DIFF
--- a/Tests/Tactility/CMakeLists.txt
+++ b/Tests/Tactility/CMakeLists.txt
@@ -2,7 +2,6 @@ project(TactilityTests)
 
 enable_language(C CXX ASM)
 
-set(CMAKE_CXX_COMPILER g++)
 
 file(GLOB_RECURSE TEST_SOURCES ${PROJECT_SOURCE_DIR}/Source/*.cpp)
 add_executable(TactilityTests EXCLUDE_FROM_ALL ${TEST_SOURCES})

--- a/Tests/Tactility/Source/AppManifestParsingTest.cpp
+++ b/Tests/Tactility/Source/AppManifestParsingTest.cpp
@@ -1,4 +1,4 @@
-#include "../../TactilityCore/Source/TestFile.h"
+#include "TestFile.h"
 #include "../../Tactility/Private/Tactility/app/AppManifestParsing.h"
 #include "../../Tactility/Private/Tactility/app/AppManifestParsingInternal.h"
 

--- a/Tests/Tactility/Source/PropertiesFileTest.cpp
+++ b/Tests/Tactility/Source/PropertiesFileTest.cpp
@@ -1,4 +1,4 @@
-#include "../../TactilityCore/Source/TestFile.h"
+#include "TestFile.h"
 #include "../../Tactility/Include/Tactility/file/PropertiesFile.h"
 
 #include "doctest.h"

--- a/Tests/TactilityFreeRtos/CMakeLists.txt
+++ b/Tests/TactilityFreeRtos/CMakeLists.txt
@@ -2,7 +2,6 @@ project(TactilityFreeRtosTests)
 
 enable_language(C CXX ASM)
 
-set(CMAKE_CXX_COMPILER g++)
 
 file(GLOB_RECURSE TEST_SOURCES ${PROJECT_SOURCE_DIR}/Source/*.cpp)
 add_executable(TactilityFreeRtosTests EXCLUDE_FROM_ALL ${TEST_SOURCES})

--- a/Tests/TactilityKernel/CMakeLists.txt
+++ b/Tests/TactilityKernel/CMakeLists.txt
@@ -2,7 +2,6 @@ project(TactilityKernelTests)
 
 enable_language(C CXX ASM)
 
-set(CMAKE_CXX_COMPILER g++)
 
 file(GLOB_RECURSE TEST_SOURCES ${PROJECT_SOURCE_DIR}/Source/*.cpp)
 add_executable(TactilityKernelTests EXCLUDE_FROM_ALL ${TEST_SOURCES})

--- a/Tests/crypt-module/CMakeLists.txt
+++ b/Tests/crypt-module/CMakeLists.txt
@@ -2,8 +2,6 @@ project(CryptModuleTests)
 
 enable_language(C CXX ASM)
 
-set(CMAKE_CXX_COMPILER g++)
-
 file(GLOB_RECURSE TEST_SOURCES ${PROJECT_SOURCE_DIR}/Source/*.cpp)
 add_executable(CryptModuleTests EXCLUDE_FROM_ALL ${TEST_SOURCES})
 


### PR DESCRIPTION
## What this fixes

Two small, independent issues in the test tree, bundled because both only affect `Tests/`:

### 1. Test build is broken on `main` after #550 (TactilityCore removal)

#550 moved `TestFile.h` from `Tests/TactilityCore/Source/` to `Tests/Tactility/Source/`, but two test sources still include it from the old path:

- `Tests/Tactility/Source/AppManifestParsingTest.cpp`
- `Tests/Tactility/Source/PropertiesFileTest.cpp`

```
fatal error: ../../TactilityCore/Source/TestFile.h: No such file or directory
```

Both files sit in the same directory as the moved header, so the include is now just `"TestFile.h"`.

### 2. Per-suite `set(CMAKE_CXX_COMPILER g++)` overrides the configured toolchain

Four test CMakeLists (`Tests/Tactility`, `Tests/TactilityKernel`, `Tests/TactilityFreeRtos`, `Tests/crypt-module`) hardcode `set(CMAKE_CXX_COMPILER g++)`, silently discarding whatever `-DCMAKE_CXX_COMPILER=...` the build was configured with. (Setting `CMAKE_CXX_COMPILER` after `project()` is also unsupported per CMake docs.)

This breaks test builds on any host where `/usr/bin/g++` predates the project's C++23 baseline. Concrete example: on Ubuntu with system g++ 11, the firmware builds fine with a configured GCC 13 toolchain, but the tests are forced onto g++ 11 and fail on C++23 `static operator()`:

```
Tactility/MessageQueue.h:30:21: error: 'static void ... operator()(QueueHandle_t)'
    must be a non-static member function
```

Removing the override lets the test targets inherit the top-level compiler like every other target. CI (`ubuntu-latest`) is unaffected either way since its default g++ is new enough.

## Verification

On this branch, configured with GCC 13 on a Ubuntu host whose system g++ is 11:

- `ninja build-tests` compiles clean (previously failed on both issues above)
- `ctest`: all 4 suites pass (`TactilityFreeRtosTests`, `TactilityKernelTests`, `TactilityTests`, `CryptModuleTests`), re-run 3× to confirm stability

## Notes for review

- Diff is intentionally minimal: 2 include-path fixes + 4 deleted `set()` lines, nothing else.
- `Tests/crypt-module/CMakeLists.txt` is new from #549 and appears to have inherited the hardcoded compiler line from the older suites — worth avoiding in future test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed hard-coded compiler settings from multiple test projects so builds now follow the active toolchain configuration.
  * Updated test includes to use a cleaner, direct header path.

* **Tests**
  * Kept test behavior unchanged while improving build portability and include handling across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->