### PR TITLE
Show a confirmed shutdown screen before cutting power

### DIFF
--- a/Tactility/Include/Tactility/hal/display/DisplayDevice.h
+++ b/Tactility/Include/Tactility/hal/display/DisplayDevice.h
@@ -29,6 +29,14 @@ public:
     /** For e-paper screens */
     virtual void requestFullRefresh() {}
 
+    /** Blocks until any frame already handed to this display has physically
+     * finished drawing. Displays that draw synchronously within their flush
+     * callback can rely on the default no-op; displays with an asynchronous
+     * refresh pipeline (e.g. e-paper, where a full refresh can take seconds)
+     * should override this so callers can safely do something irreversible
+     * (like cutting power) right after a screen update. */
+    virtual void waitForFlushComplete() {}
+
     /** Could return nullptr if not started */
     virtual std::shared_ptr<touch::TouchDevice> getTouchDevice() = 0;
 

--- a/Tactility/Source/Tactility.cpp
+++ b/Tactility/Source/Tactility.cpp
@@ -103,6 +103,7 @@ namespace app {
     namespace localesettings { extern const AppManifest manifest; }
     namespace notes { extern const AppManifest manifest; }
     namespace power { extern const AppManifest manifest; }
+    namespace poweroff { extern const AppManifest manifest; }
     namespace selectiondialog { extern const AppManifest manifest; }
     namespace settings { extern const AppManifest manifest; }
     namespace setup { extern const AppManifest manifest; }
@@ -157,6 +158,7 @@ static void registerInternalApps() {
     addAppManifest(app::launcher::manifest);
     addAppManifest(app::localesettings::manifest);
     addAppManifest(app::notes::manifest);
+    addAppManifest(app::poweroff::manifest);
     addAppManifest(app::settings::manifest);
     addAppManifest(app::selectiondialog::manifest);
     addAppManifest(app::setup::manifest);

--- a/Tactility/Source/app/launcher/Launcher.cpp
+++ b/Tactility/Source/app/launcher/Launcher.cpp
@@ -4,7 +4,6 @@
 #include <Tactility/app/AppPaths.h>
 #include <Tactility/app/AppRegistration.h>
 #include <Tactility/app/setup/Setup.h>
-#include <Tactility/hal/power/PowerDevice.h>
 #include <Tactility/service/loader/Loader.h>
 #include <Tactility/settings/BootSettings.h>
 
@@ -66,26 +65,9 @@ class LauncherApp final : public App {
         return apps_button;
     }
 
-    static bool shouldShowPowerButton() {
-        bool show_power_button = false;
-        hal::findDevices<hal::power::PowerDevice>(hal::Device::Type::Power, [&show_power_button](const auto& device) {
-            if (device->supportsPowerOff()) {
-                show_power_button = true;
-                return false; // stop iterating
-            } else {
-                return true; // continue iterating
-            }
-        });
-        return show_power_button;
-    }
-
     static void onAppPressed(lv_event_t* e) {
         auto* appId = static_cast<const char*>(lv_event_get_user_data(e));
         start(appId);
-    }
-
-    static void onPowerOffPressed(lv_event_t* /*e*/) {
-        start("PowerOff");
     }
 
     // The screen object outlives the launcher's views (it's recreated by GuiService::redraw()
@@ -198,19 +180,6 @@ public:
         // handler is attached there, with buttons_wrapper passed through as user data.
         lv_obj_add_event_cb(lv_obj_get_screen(parent), onButtonsWrapperResized, LV_EVENT_SIZE_CHANGED, buttons_wrapper);
         lv_obj_add_event_cb(buttons_wrapper, onButtonsWrapperDeleted, LV_EVENT_DELETE, nullptr);
-
-        if (shouldShowPowerButton()) {
-            auto* power_button = lv_button_create(parent);
-            lv_obj_set_style_pad_all(power_button, 8, 0);
-            lv_obj_align(power_button, LV_ALIGN_BOTTOM_MID, 0, -10);
-            lv_obj_add_event_cb(power_button, onPowerOffPressed, LV_EVENT_SHORT_CLICKED, nullptr);
-            lv_obj_set_style_shadow_width(power_button, 0, LV_STATE_DEFAULT);
-            lv_obj_set_style_bg_opa(power_button, 0, LV_PART_MAIN);
-
-            auto* power_label = lv_label_create(power_button);
-            lv_label_set_text(power_label, LV_SYMBOL_POWER);
-            lv_obj_set_style_text_color(power_label, lv_theme_get_color_primary(parent), LV_STATE_DEFAULT);
-        }
     }
 };
 

--- a/Tactility/Source/app/launcher/Launcher.cpp
+++ b/Tactility/Source/app/launcher/Launcher.cpp
@@ -7,6 +7,7 @@
 #include <Tactility/app/setup/Setup.h>
 #include <Tactility/hal/display/DisplayDevice.h>
 #include <Tactility/hal/power/PowerDevice.h>
+#include <Tactility/lvgl/LvglSync.h>
 #include <Tactility/service/loader/Loader.h>
 #include <Tactility/settings/BootSettings.h>
 
@@ -92,8 +93,16 @@ class LauncherApp final : public App {
      * synchronously, and waits for the display to confirm the draw physically
      * finished. On e-paper this is what's left showing once power cuts, so it
      * doubles as visual confirmation that the device shut down cleanly rather
-     * than crashed or hung. */
+     * than crashed or hung.
+     *
+     * Called from App::onResult, which runs on the loader dispatcher thread,
+     * not the LVGL thread — every LVGL call here must happen under the LVGL
+     * lock, same as DisplayIdleService's screensaver overlay. */
     static void showPoweredOffScreenAndWait(hal::display::DisplayDevice* display) {
+        if (!lvgl::lock(lvgl::defaultLockTime)) {
+            return;
+        }
+
         auto* screen = lv_obj_create(nullptr);
         lv_obj_set_style_bg_color(screen, lv_color_white(), 0);
         lv_obj_set_flex_flow(screen, LV_FLEX_FLOW_COLUMN);
@@ -115,6 +124,8 @@ class LauncherApp final : public App {
             }
             display->waitForFlushComplete();
         }
+
+        lvgl::unlock();
     }
 
     static void performPowerOff() {

--- a/Tactility/Source/app/launcher/Launcher.cpp
+++ b/Tactility/Source/app/launcher/Launcher.cpp
@@ -3,6 +3,7 @@
 #include <Tactility/app/AppContext.h>
 #include <Tactility/app/AppPaths.h>
 #include <Tactility/app/AppRegistration.h>
+#include <Tactility/app/alertdialog/AlertDialog.h>
 #include <Tactility/app/setup/Setup.h>
 #include <Tactility/hal/display/DisplayDevice.h>
 #include <Tactility/hal/power/PowerDevice.h>
@@ -35,6 +36,8 @@ static int32_t computeButtonMargin(int32_t available_span, int32_t total_button_
 }
 
 class LauncherApp final : public App {
+
+    LaunchId powerOffConfirmLaunchId = 0;
 
     static lv_obj_t* createAppButton(lv_obj_t* parent, UiDensity uiDensity, const char* imageFile, const char* appId, int32_t itemMargin, bool isLandscape) {
         const auto button_size = lvgl_get_launcher_icon_font_height();
@@ -114,7 +117,7 @@ class LauncherApp final : public App {
         }
     }
 
-    static void onPowerOffPressed(lv_event_t* e) {
+    static void performPowerOff() {
         auto power = hal::findFirstDevice<hal::power::PowerDevice>(hal::Device::Type::Power);
         if (power == nullptr || !power->supportsPowerOff()) {
             return;
@@ -124,6 +127,17 @@ class LauncherApp final : public App {
         showPoweredOffScreenAndWait(display.get());
 
         power->powerOff();
+    }
+
+    static void onPowerOffPressed(lv_event_t* e) {
+        auto* self = static_cast<LauncherApp*>(lv_event_get_user_data(e));
+        auto power = hal::findFirstDevice<hal::power::PowerDevice>(hal::Device::Type::Power);
+        if (power == nullptr || !power->supportsPowerOff()) {
+            return;
+        }
+
+        auto choices = std::vector { "Power off", "Cancel" };
+        self->powerOffConfirmLaunchId = alertdialog::start("Power off?", "Are you sure you want to power off?", choices);
     }
 
     // The screen object outlives the launcher's views (it's recreated by GuiService::redraw()
@@ -197,6 +211,16 @@ public:
         }
     }
 
+    void onResult(AppContext& appContext, LaunchId launchId, Result result, std::unique_ptr<Bundle> resultData) override {
+        if (launchId == powerOffConfirmLaunchId &&
+            result == Result::Ok &&
+            resultData != nullptr &&
+            alertdialog::getResultIndex(*resultData) == 0
+        ) {
+            performPowerOff();
+        }
+    }
+
     void onShow(AppContext& app, lv_obj_t* parent) override {
         auto* buttons_wrapper = lv_obj_create(parent);
 
@@ -241,7 +265,7 @@ public:
             auto* power_button = lv_button_create(parent);
             lv_obj_set_style_pad_all(power_button, 8, 0);
             lv_obj_align(power_button, LV_ALIGN_BOTTOM_MID, 0, -10);
-            lv_obj_add_event_cb(power_button, onPowerOffPressed, LV_EVENT_SHORT_CLICKED, nullptr);
+            lv_obj_add_event_cb(power_button, onPowerOffPressed, LV_EVENT_SHORT_CLICKED, this);
             lv_obj_set_style_shadow_width(power_button, 0, LV_STATE_DEFAULT);
             lv_obj_set_style_bg_opa(power_button, 0, LV_PART_MAIN);
 

--- a/Tactility/Source/app/launcher/Launcher.cpp
+++ b/Tactility/Source/app/launcher/Launcher.cpp
@@ -3,11 +3,8 @@
 #include <Tactility/app/AppContext.h>
 #include <Tactility/app/AppPaths.h>
 #include <Tactility/app/AppRegistration.h>
-#include <Tactility/app/alertdialog/AlertDialog.h>
 #include <Tactility/app/setup/Setup.h>
-#include <Tactility/hal/display/DisplayDevice.h>
 #include <Tactility/hal/power/PowerDevice.h>
-#include <Tactility/lvgl/LvglSync.h>
 #include <Tactility/service/loader/Loader.h>
 #include <Tactility/settings/BootSettings.h>
 
@@ -37,8 +34,6 @@ static int32_t computeButtonMargin(int32_t available_span, int32_t total_button_
 }
 
 class LauncherApp final : public App {
-
-    LaunchId powerOffConfirmLaunchId = 0;
 
     static lv_obj_t* createAppButton(lv_obj_t* parent, UiDensity uiDensity, const char* imageFile, const char* appId, int32_t itemMargin, bool isLandscape) {
         const auto button_size = lvgl_get_launcher_icon_font_height();
@@ -89,66 +84,8 @@ class LauncherApp final : public App {
         start(appId);
     }
 
-    /** Replaces the screen with a plain "powered off" message, forces it to draw
-     * synchronously, and waits for the display to confirm the draw physically
-     * finished. On e-paper this is what's left showing once power cuts, so it
-     * doubles as visual confirmation that the device shut down cleanly rather
-     * than crashed or hung.
-     *
-     * Called from App::onResult, which runs on the loader dispatcher thread,
-     * not the LVGL thread — every LVGL call here must happen under the LVGL
-     * lock, same as DisplayIdleService's screensaver overlay. */
-    static void showPoweredOffScreenAndWait(hal::display::DisplayDevice* display) {
-        if (!lvgl::lock(lvgl::defaultLockTime)) {
-            return;
-        }
-
-        auto* screen = lv_obj_create(nullptr);
-        lv_obj_set_style_bg_color(screen, lv_color_white(), 0);
-        lv_obj_set_flex_flow(screen, LV_FLEX_FLOW_COLUMN);
-        lv_obj_set_flex_align(screen, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-
-        auto* title = lv_label_create(screen);
-        lv_label_set_text(title, "Tactility OS");
-        lv_obj_set_style_text_font(title, lvgl_get_text_font(FONT_SIZE_LARGE), 0);
-
-        auto* subtitle = lv_label_create(screen);
-        lv_label_set_text(subtitle, "Powered off");
-
-        lv_screen_load(screen);
-
-        if (display != nullptr) {
-            auto* lvgl_display = display->getLvglDisplay();
-            if (lvgl_display != nullptr) {
-                lv_refr_now(lvgl_display);
-            }
-            display->waitForFlushComplete();
-        }
-
-        lvgl::unlock();
-    }
-
-    static void performPowerOff() {
-        auto power = hal::findFirstDevice<hal::power::PowerDevice>(hal::Device::Type::Power);
-        if (power == nullptr || !power->supportsPowerOff()) {
-            return;
-        }
-
-        auto display = hal::findFirstDevice<hal::display::DisplayDevice>(hal::Device::Type::Display);
-        showPoweredOffScreenAndWait(display.get());
-
-        power->powerOff();
-    }
-
-    static void onPowerOffPressed(lv_event_t* e) {
-        auto* self = static_cast<LauncherApp*>(lv_event_get_user_data(e));
-        auto power = hal::findFirstDevice<hal::power::PowerDevice>(hal::Device::Type::Power);
-        if (power == nullptr || !power->supportsPowerOff()) {
-            return;
-        }
-
-        auto choices = std::vector { "Power off", "Cancel" };
-        self->powerOffConfirmLaunchId = alertdialog::start("Power off?", "Are you sure you want to power off?", choices);
+    static void onPowerOffPressed(lv_event_t* /*e*/) {
+        start("PowerOff");
     }
 
     // The screen object outlives the launcher's views (it's recreated by GuiService::redraw()
@@ -222,16 +159,6 @@ public:
         }
     }
 
-    void onResult(AppContext& appContext, LaunchId launchId, Result result, std::unique_ptr<Bundle> resultData) override {
-        if (launchId == powerOffConfirmLaunchId &&
-            result == Result::Ok &&
-            resultData != nullptr &&
-            alertdialog::getResultIndex(*resultData) == 0
-        ) {
-            performPowerOff();
-        }
-    }
-
     void onShow(AppContext& app, lv_obj_t* parent) override {
         auto* buttons_wrapper = lv_obj_create(parent);
 
@@ -276,7 +203,7 @@ public:
             auto* power_button = lv_button_create(parent);
             lv_obj_set_style_pad_all(power_button, 8, 0);
             lv_obj_align(power_button, LV_ALIGN_BOTTOM_MID, 0, -10);
-            lv_obj_add_event_cb(power_button, onPowerOffPressed, LV_EVENT_SHORT_CLICKED, this);
+            lv_obj_add_event_cb(power_button, onPowerOffPressed, LV_EVENT_SHORT_CLICKED, nullptr);
             lv_obj_set_style_shadow_width(power_button, 0, LV_STATE_DEFAULT);
             lv_obj_set_style_bg_opa(power_button, 0, LV_PART_MAIN);
 

--- a/Tactility/Source/app/launcher/Launcher.cpp
+++ b/Tactility/Source/app/launcher/Launcher.cpp
@@ -4,6 +4,7 @@
 #include <Tactility/app/AppPaths.h>
 #include <Tactility/app/AppRegistration.h>
 #include <Tactility/app/setup/Setup.h>
+#include <Tactility/hal/display/DisplayDevice.h>
 #include <Tactility/hal/power/PowerDevice.h>
 #include <Tactility/service/loader/Loader.h>
 #include <Tactility/settings/BootSettings.h>
@@ -84,11 +85,45 @@ class LauncherApp final : public App {
         start(appId);
     }
 
+    /** Replaces the screen with a plain "powered off" message, forces it to draw
+     * synchronously, and waits for the display to confirm the draw physically
+     * finished. On e-paper this is what's left showing once power cuts, so it
+     * doubles as visual confirmation that the device shut down cleanly rather
+     * than crashed or hung. */
+    static void showPoweredOffScreenAndWait(hal::display::DisplayDevice* display) {
+        auto* screen = lv_obj_create(nullptr);
+        lv_obj_set_style_bg_color(screen, lv_color_white(), 0);
+        lv_obj_set_flex_flow(screen, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_flex_align(screen, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+        auto* title = lv_label_create(screen);
+        lv_label_set_text(title, "Tactility OS");
+        lv_obj_set_style_text_font(title, lvgl_get_text_font(FONT_SIZE_LARGE), 0);
+
+        auto* subtitle = lv_label_create(screen);
+        lv_label_set_text(subtitle, "Powered off");
+
+        lv_screen_load(screen);
+
+        if (display != nullptr) {
+            auto* lvgl_display = display->getLvglDisplay();
+            if (lvgl_display != nullptr) {
+                lv_refr_now(lvgl_display);
+            }
+            display->waitForFlushComplete();
+        }
+    }
+
     static void onPowerOffPressed(lv_event_t* e) {
         auto power = hal::findFirstDevice<hal::power::PowerDevice>(hal::Device::Type::Power);
-        if (power != nullptr && power->supportsPowerOff()) {
-            power->powerOff();
+        if (power == nullptr || !power->supportsPowerOff()) {
+            return;
         }
+
+        auto display = hal::findFirstDevice<hal::display::DisplayDevice>(hal::Device::Type::Display);
+        showPoweredOffScreenAndWait(display.get());
+
+        power->powerOff();
     }
 
     // The screen object outlives the launcher's views (it's recreated by GuiService::redraw()

--- a/Tactility/Source/app/launcher/Launcher.cpp
+++ b/Tactility/Source/app/launcher/Launcher.cpp
@@ -4,6 +4,7 @@
 #include <Tactility/app/AppPaths.h>
 #include <Tactility/app/AppRegistration.h>
 #include <Tactility/app/setup/Setup.h>
+#include <Tactility/hal/power/PowerDevice.h>
 #include <Tactility/service/loader/Loader.h>
 #include <Tactility/settings/BootSettings.h>
 
@@ -68,6 +69,19 @@ class LauncherApp final : public App {
     static void onAppPressed(lv_event_t* e) {
         auto* appId = static_cast<const char*>(lv_event_get_user_data(e));
         start(appId);
+    }
+
+    static bool shouldShowPowerButton() {
+        bool show_power_button = false;
+        hal::findDevices<hal::power::PowerDevice>(hal::Device::Type::Power, [&show_power_button](const auto& device) {
+            if (device->supportsPowerOff()) {
+                show_power_button = true;
+                return false; // stop iterating
+            } else {
+                return true; // continue iterating
+            }
+        });
+        return show_power_button;
     }
 
     // The screen object outlives the launcher's views (it's recreated by GuiService::redraw()
@@ -180,6 +194,21 @@ public:
         // handler is attached there, with buttons_wrapper passed through as user data.
         lv_obj_add_event_cb(lv_obj_get_screen(parent), onButtonsWrapperResized, LV_EVENT_SIZE_CHANGED, buttons_wrapper);
         lv_obj_add_event_cb(buttons_wrapper, onButtonsWrapperDeleted, LV_EVENT_DELETE, nullptr);
+
+        // Some devices (e.g. T-Lora Pager) have no other way to power off, so the
+        // button stays in the launcher; the confirmation flow lives in the PowerOff app.
+        if (shouldShowPowerButton()) {
+            auto* power_button = lv_button_create(parent);
+            lv_obj_set_style_pad_all(power_button, 8, 0);
+            lv_obj_align(power_button, LV_ALIGN_BOTTOM_MID, 0, -10);
+            lv_obj_add_event_cb(power_button, onAppPressed, LV_EVENT_SHORT_CLICKED, (void*)"PowerOff");
+            lv_obj_set_style_shadow_width(power_button, 0, LV_STATE_DEFAULT);
+            lv_obj_set_style_bg_opa(power_button, 0, LV_PART_MAIN);
+
+            auto* power_label = lv_label_create(power_button);
+            lv_label_set_text(power_label, LV_SYMBOL_POWER);
+            lv_obj_set_style_text_color(power_label, lv_theme_get_color_primary(parent), LV_STATE_DEFAULT);
+        }
     }
 };
 

--- a/Tactility/Source/app/poweroff/PowerOff.cpp
+++ b/Tactility/Source/app/poweroff/PowerOff.cpp
@@ -1,0 +1,100 @@
+#include <Tactility/app/AppContext.h>
+#include <Tactility/app/AppRegistration.h>
+#include <Tactility/hal/display/DisplayDevice.h>
+#include <Tactility/hal/power/PowerDevice.h>
+#include <Tactility/service/loader/Loader.h>
+
+#include <lvgl.h>
+#include <tactility/hal/Device.h>
+#include <tactility/lvgl_fonts.h>
+
+namespace tt::app::poweroff {
+
+extern const AppManifest manifest;
+
+class PowerOffApp final : public App {
+
+    /** Replaces the screen with a plain "powered off" message, forces it to draw
+     * synchronously, and waits for the display to confirm the draw physically
+     * finished. On e-paper this is what's left showing once power cuts, so it
+     * doubles as visual confirmation that the device shut down cleanly rather
+     * than crashed or hung. Called from an LVGL button click callback, so it's
+     * already running on the LVGL thread. */
+    static void showPoweredOffScreenAndWait(hal::display::DisplayDevice* display) {
+        auto* screen = lv_obj_create(nullptr);
+        lv_obj_set_style_bg_color(screen, lv_color_white(), 0);
+        lv_obj_set_flex_flow(screen, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_flex_align(screen, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+        auto* title = lv_label_create(screen);
+        lv_label_set_text(title, "Tactility OS");
+        lv_obj_set_style_text_font(title, lvgl_get_text_font(FONT_SIZE_LARGE), 0);
+
+        auto* subtitle = lv_label_create(screen);
+        lv_label_set_text(subtitle, "Powered off");
+
+        lv_screen_load(screen);
+
+        if (display != nullptr) {
+            auto* lvgl_display = display->getLvglDisplay();
+            if (lvgl_display != nullptr) {
+                lv_refr_now(lvgl_display);
+            }
+            display->waitForFlushComplete();
+        }
+    }
+
+    static void onYesPressed(lv_event_t* /*event*/) {
+        auto power = hal::findFirstDevice<hal::power::PowerDevice>(hal::Device::Type::Power);
+        if (power == nullptr || !power->supportsPowerOff()) {
+            return;
+        }
+
+        auto display = hal::findFirstDevice<hal::display::DisplayDevice>(hal::Device::Type::Display);
+        showPoweredOffScreenAndWait(display.get());
+
+        power->powerOff();
+    }
+
+    static void onNoPressed(lv_event_t* /*event*/) {
+        stop(manifest.appId);
+    }
+
+public:
+
+    void onShow(AppContext& /*app*/, lv_obj_t* parent) override {
+        lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_flex_align(parent, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+        auto* label = lv_label_create(parent);
+        lv_label_set_text(label, "Power off?");
+        lv_obj_set_style_text_font(label, lvgl_get_text_font(FONT_SIZE_LARGE), 0);
+
+        auto* button_wrapper = lv_obj_create(parent);
+        lv_obj_set_flex_flow(button_wrapper, LV_FLEX_FLOW_ROW);
+        lv_obj_set_size(button_wrapper, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+        lv_obj_set_style_pad_all(button_wrapper, 0, 0);
+        lv_obj_set_style_border_width(button_wrapper, 0, 0);
+        lv_obj_set_flex_align(button_wrapper, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+        auto* yes_button = lv_button_create(button_wrapper);
+        auto* yes_label = lv_label_create(yes_button);
+        lv_label_set_text(yes_label, "Yes");
+        lv_obj_add_event_cb(yes_button, onYesPressed, LV_EVENT_SHORT_CLICKED, nullptr);
+
+        auto* no_button = lv_button_create(button_wrapper);
+        auto* no_label = lv_label_create(no_button);
+        lv_label_set_text(no_label, "No");
+        lv_obj_add_event_cb(no_button, onNoPressed, LV_EVENT_SHORT_CLICKED, nullptr);
+    }
+};
+
+extern const AppManifest manifest = {
+    .appId = "PowerOff",
+    .appName = "Power Off",
+    .appCategory = Category::System,
+    .appFlags = AppManifest::Flags::HideStatusBar | AppManifest::Flags::Hidden,
+    .createApp = create<PowerOffApp>
+};
+
+} // namespace

--- a/Tactility/Source/app/poweroff/PowerOff.cpp
+++ b/Tactility/Source/app/poweroff/PowerOff.cpp
@@ -7,6 +7,7 @@
 #include <lvgl.h>
 #include <tactility/hal/Device.h>
 #include <tactility/lvgl_fonts.h>
+#include <tactility/lvgl_icon_shared.h>
 
 namespace tt::app::poweroff {
 
@@ -94,8 +95,9 @@ public:
 extern const AppManifest manifest = {
     .appId = "PowerOff",
     .appName = "Power Off",
-    .appCategory = Category::System,
-    .appFlags = AppManifest::Flags::HideStatusBar | AppManifest::Flags::Hidden,
+    .appIcon = LVGL_ICON_SHARED_POWER_SETTINGS_NEW,
+    .appCategory = Category::Settings,
+    .appFlags = AppManifest::Flags::HideStatusBar,
     .createApp = create<PowerOffApp>
 };
 

--- a/Tactility/Source/app/poweroff/PowerOff.cpp
+++ b/Tactility/Source/app/poweroff/PowerOff.cpp
@@ -29,9 +29,11 @@ class PowerOffApp final : public App {
         auto* title = lv_label_create(screen);
         lv_label_set_text(title, "Tactility OS");
         lv_obj_set_style_text_font(title, lvgl_get_text_font(FONT_SIZE_LARGE), 0);
+        lv_obj_set_style_text_color(title, lv_color_black(), 0);
 
         auto* subtitle = lv_label_create(screen);
         lv_label_set_text(subtitle, "Powered off");
+        lv_obj_set_style_text_color(subtitle, lv_color_black(), 0);
 
         lv_screen_load(screen);
 


### PR DESCRIPTION
Small, standalone core change — no board-specific code, doesn't depend on any of my other open PRs.

## Motivation

Today, `Launcher.cpp`'s power-off button calls `PowerDevice::powerOff()` directly, with no visual feedback. On a normal display that's fine (the screen goes dark with the power rail). On an e-paper display, though, the panel keeps showing whatever was drawn last — so if power cuts mid-refresh (or while still showing the app the user was in), there's no way to tell "the device shut down cleanly" from "the device crashed or hung."

I hit this while building an e-paper board (T-Deck Max, #539/#552/#553): those PRs' `GDEQ031T10` driver refreshes asynchronously on a background task (needed to keep input responsive during multi-second e-paper refreshes), so simply drawing a message isn't enough — the caller needs to know the panel has *physically* finished drawing before the power rail dies, or the message itself could get cut off mid-refresh.

## What this adds

- `DisplayDevice::waitForFlushComplete()` — a new virtual, default no-op. Displays that draw synchronously in their flush callback (i.e. every current upstream display) are completely unaffected. Displays with an async refresh pipeline can override it to block until any pending frame has physically finished drawing.
- `Launcher.cpp`'s power-off handler now shows a plain "Tactility OS / Powered off" screen, forces a synchronous LVGL redraw (`lv_refr_now`), calls `waitForFlushComplete()`, and only then calls `powerOff()`.

No existing driver needs changes — the new virtual defaults to a no-op everywhere, so this is a pure API addition plus a small UX improvement for every board with a power-off-capable device.

## Verification

- Simulator build clean.
- Verified end-to-end on real T-Deck Max hardware (the actual motivating case, using my as-yet-unmerged `GDEQ031T10` driver + a `waitForFlushComplete()` override): pressed the power-off button, the "Tactility OS / Powered off" screen rendered fully before the board's power rail cut, and the panel kept showing it after power-off (no garbled/partial refresh). Device powered back on cleanly when USB was reconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Power Off” app with a “Power off?” confirmation dialog (“Yes” / “No”).
* **Bug Fixes**
  * Selecting “Yes” now ensures the final screen update finishes rendering before powering down, improving reliability on slower/asynchronous display hardware.
* **Changes**
  * Updated the launcher’s power button to launch the new “Power Off” app (instead of directly invoking power-off behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->