### PR TITLE
Generate device matrix and add missing symbol

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,57 +30,20 @@ jobs:
         with:
           board_id: ${{ matrix.board.id }}
           arch: ${{ matrix.board.arch }}
-  BuildFirmware:
-    strategy:
-      matrix:
-        board: [
-          { id: btt-panda-touch, arch: esp32s3 },
-          { id: cyd-2432s024c, arch: esp32 },
-          { id: cyd-2432s024r, arch: esp32 },
-          { id: cyd-2432s028r, arch: esp32 },
-          { id: cyd-2432s028rv3, arch: esp32 },
-          { id: cyd-e32r28t, arch: esp32 },
-          { id: cyd-e32r32p, arch: esp32 },
-          { id: cyd-2432s032c, arch: esp32 },
-          { id: cyd-3248s035c, arch: esp32 },
-          { id: cyd-8048s043c, arch: esp32s3 },
-          { id: cyd-4848s040c, arch: esp32s3 },
-          { id: elecrow-crowpanel-advance-28, arch: esp32s3 },
-          { id: elecrow-crowpanel-advance-35, arch: esp32s3 },
-          { id: elecrow-crowpanel-advance-50, arch: esp32s3 },
-          { id: elecrow-crowpanel-basic-28, arch: esp32 },
-          { id: elecrow-crowpanel-basic-35, arch: esp32 },
-          { id: elecrow-crowpanel-basic-50, arch: esp32s3 },
-          { id: guition-jc1060p470ciwy, arch: esp32p4 },
-          { id: guition-jc2432w328c, arch: esp32 },
-          { id: guition-jc3248w535c, arch: esp32s3 },
-          { id: guition-jc8048w550c, arch: esp32s3 },
-          { id: heltec-wifi-lora-32-v3, arch: esp32s3 },
-          { id: lilygo-tdeck, arch: esp32s3 },
-          { id: lilygo-thmi, arch: esp32s3 },
-          { id: lilygo-tdongle-s3, arch: esp32s3 },
-          { id: lilygo-tdisplay-s3, arch: esp32s3 },
-          { id: lilygo-tlora-pager, arch: esp32s3 },
-          { id: lilygo-tdisplay, arch: esp32 },
-          { id: m5stack-cardputer, arch: esp32s3 },
-          { id: m5stack-cardputer-adv, arch: esp32s3 },
-          { id: m5stack-core2, arch: esp32 },
-          { id: m5stack-cores3, arch: esp32s3 },
-          { id: m5stack-papers3, arch: esp32s3 },
-          { id: m5stack-stackchan, arch: esp32s3 },
-          { id: m5stack-stickc-plus2, arch: esp32 },
-          { id: m5stack-sticks3, arch: esp32s3 },
-          { id: m5stack-tab5, arch: esp32p4 },
-          { id: unphone, arch: esp32s3 },
-          { id: waveshare-esp32-s3-geek, arch: esp32s3 },
-          { id: waveshare-s3-lcd-13, arch: esp32s3 },
-          { id: waveshare-s3-touch-lcd-128, arch: esp32s3 },
-          { id: waveshare-s3-touch-lcd-147, arch: esp32s3 },
-          { id: waveshare-s3-touch-lcd-43, arch: esp32s3 },
-          { id: wireless-tag-wt32-sc01-plus, arch: esp32s3 }
-        ]
+  GenerateDeviceMatrix:
     runs-on: ubuntu-latest
     needs: [ BuildSdk ]
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        run: python3 Buildscripts/gh-generate-device-matrix.py
+  BuildFirmware:
+    runs-on: ubuntu-latest
+    needs: GenerateDeviceMatrix
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-device-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: GenerateDeviceMatrix
     strategy:
-      matrix: ${{ fromJSON(needs.generate-device-matrix.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.GenerateDeviceMatrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - id: set-matrix
         run: python3 Buildscripts/gh-generate-device-matrix.py
   BuildFirmware:

--- a/Buildscripts/gh-generate-device-matrix.py
+++ b/Buildscripts/gh-generate-device-matrix.py
@@ -1,0 +1,57 @@
+import fnmatch
+import json
+import os
+import sys
+
+DEVICES_DIRECTORY = os.path.join(os.path.dirname(__file__), "..", "Devices")
+
+IGNORE_LIST = {
+    "simulator",
+    "generic-*",
+}
+
+
+def is_ignored(device_id):
+    return any(fnmatch.fnmatch(device_id, pattern) for pattern in IGNORE_LIST)
+
+def read_properties_file(path):
+    properties = {}
+    with open(path, "r") as file:
+        for line in file:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            key, sep, value = line.partition("=")
+            if not sep:
+                continue
+            properties[key.strip()] = value.strip()
+    return properties
+
+def get_board_entries():
+    boards = []
+    for device_id in sorted(os.listdir(DEVICES_DIRECTORY)):
+        if is_ignored(device_id):
+            continue
+        device_dir = os.path.join(DEVICES_DIRECTORY, device_id)
+        properties_path = os.path.join(device_dir, "device.properties")
+        if not os.path.isdir(device_dir) or not os.path.isfile(properties_path):
+            continue
+        properties = read_properties_file(properties_path)
+        target = properties.get("hardware.target")
+        if not target:
+            sys.exit(f"ERROR: {properties_path} has no hardware.target property")
+        boards.append({"id": device_id, "arch": target.lower()})
+    return boards
+
+def main():
+    matrix_json = json.dumps({"board": get_board_entries()})
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as file:
+            file.write(f"matrix={matrix_json}\n")
+    else:
+        print(matrix_json)
+
+if __name__ == "__main__":
+    main()

--- a/TactilityKernel/source/kernel_symbols.c
+++ b/TactilityKernel/source/kernel_symbols.c
@@ -63,6 +63,7 @@ const struct ModuleSymbol KERNEL_SYMBOLS[] = {
     DEFINE_MODULE_SYMBOL(device_exists_of_type),
     DEFINE_MODULE_SYMBOL(device_find_by_name),
     DEFINE_MODULE_SYMBOL(device_find_first_active_by_type),
+    DEFINE_MODULE_SYMBOL(device_find_first_by_type),
     // driver
     DEFINE_MODULE_SYMBOL(driver_construct),
     DEFINE_MODULE_SYMBOL(driver_destruct),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Firmware builds now automatically generate their device/architecture build matrix by scanning discovered devices instead of relying on a fixed predefined list.
* **Bug Fixes**
  * Improved kernel symbol registration so device lookup by type is resolved correctly at runtime.
* **CI / Build Automation**
  * Updated the build workflow to compute the matrix dynamically via a generation step, and feed it into the firmware build job for its build strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->