### PR TITLE
Fixes and improvements

### DIFF
--- a/Devices/guition-jc1060p470ciwy/guition,jc1060p470ciwy.dts
+++ b/Devices/guition-jc1060p470ciwy/guition,jc1060p470ciwy.dts
@@ -6,6 +6,7 @@
 #include <tactility/bindings/esp32_i2c.h>
 #include <tactility/bindings/esp32_i2s.h>
 #include <tactility/bindings/esp32_sdmmc.h>
+#include <tactility/bindings/esp32_wifi.h>
 
 /**
  * For future reference:
@@ -18,6 +19,11 @@
 / {
 	compatible = "root";
 	model = "Guition JC1060P470C-I-W-Y";
+
+	wifi0 {
+		compatible = "espressif,esp32-wifi";
+		status = "disabled";
+	};
 
 	ble0 {
 		compatible = "espressif,esp32-ble";

--- a/Devices/m5stack-stickc-plus2/device.properties
+++ b/Devices/m5stack-stickc-plus2/device.properties
@@ -1,9 +1,7 @@
 general.vendor=M5Stack
 general.name=StickC Plus2
-general.incubating=true
 
 apps.launcherAppId=Launcher
-apps.autoStartAppId=ApWebServer
 
 hardware.target=ESP32
 hardware.flashSize=8MB

--- a/Devices/m5stack-sticks3/device.properties
+++ b/Devices/m5stack-sticks3/device.properties
@@ -12,7 +12,7 @@ hardware.esptoolFlashFreq=80M
 hardware.tinyUsb=true
 hardware.bluetooth=true
 
-storage.userDataLocation=SD
+storage.userDataLocation=Internal
 
 display.size=1.14"
 display.shape=rectangle

--- a/Devices/m5stack-sticks3/m5stack,sticks3.dts
+++ b/Devices/m5stack-sticks3/m5stack,sticks3.dts
@@ -69,21 +69,6 @@
 		};
 	};
 
-	//DIY SD Card - https://wiki.bruce.computer/wiring-diagrams/m5sticks3/sd-card/
-	spi1 {
-		compatible = "espressif,esp32-spi";
-		host = <SPI3_HOST>;
-		cs-gpios = <&gpio0 7 GPIO_FLAG_NONE>;
-		pin-mosi = <&gpio0 6 GPIO_FLAG_NONE>;
-		pin-miso = <&gpio0 4 GPIO_FLAG_NONE>;
-		pin-sclk = <&gpio0 5 GPIO_FLAG_NONE>;
-	
-		sdcard@0 {
-			compatible = "espressif,esp32-sdspi";
-			frequency-khz = <20000>;
-		};
-	};
-
 	// Speaker and microphone (ES8311)
 	i2s0 {
 		compatible = "espressif,esp32-i2s";

--- a/Devices/m5stack-tab5/m5stack,tab5.dts
+++ b/Devices/m5stack-tab5/m5stack,tab5.dts
@@ -9,6 +9,7 @@
 #include <tactility/bindings/esp32_sdmmc.h>
 #include <tactility/bindings/esp32_uart.h>
 #include <tactility/bindings/esp32_usbhost.h>
+#include <tactility/bindings/esp32_wifi.h>
 #include <bindings/bmi270.h>
 #include <bindings/ina226.h>
 #include <bindings/pi4ioe5v6408.h>
@@ -18,6 +19,11 @@
 / {
 	compatible = "root";
 	model = "Tab5";
+
+	wifi0 {
+		compatible = "espressif,esp32-wifi";
+		status = "disabled";
+	};
 
 	ble0 {
 		compatible = "espressif,esp32-ble";

--- a/Tactility/Include/Tactility/service/rtctime/RtcTimeService.h
+++ b/Tactility/Include/Tactility/service/rtctime/RtcTimeService.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Tactility/kernel/SystemEvents.h>
+#include <Tactility/SystemEvents.h>
 #include <Tactility/service/Service.h>
 #include <Tactility/service/ServiceContext.h>
 #include <Tactility/service/rtctime/RtcTime.h>

--- a/TactilityKernel/include/tactility/service/service_manifest.h
+++ b/TactilityKernel/include/tactility/service/service_manifest.h
@@ -12,6 +12,7 @@ extern "C" {
 // so the callback types below are declared directly in terms of ServiceInstance to avoid
 // a conflicting forward-declaration of an unrelated "ServiceContext" struct tag.
 struct ServiceInstance;
+struct ServiceManifest;
 
 /**
  * Allocates and initializes the service's custom data.


### PR DESCRIPTION
- **Fixes**
  - Added missing Wi-Fi hardware configuration support for P4 devices.
  - Fixed build warning
  - Fixed build wrt Tab5

- **Changes**
  - M5Stack StickS3: Switched default storage location from SD to Internal
  - M5Stack StickS3: Removed DIY SD card support over SPI
  - M5Stack StickC Plus2: Removed the automatic startup of the web server