### PR TITLE
Update dependencies in Devices/ and remove "useDeprecatedHal"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,6 @@ else ()
     # Devices/simulator/Source/Simulator.cpp always defines its own hardwareConfiguration; without
     # this, Firmware/Source/Main.cpp's #else branch also defines an empty one (its ESP32-only
     # fallback for devices migrated off the deprecated HAL), causing a duplicate-definition link error.
-    add_compile_definitions(CONFIG_TT_USE_DEPRECATED_HAL)
     add_compile_definitions(CONFIG_TT_DEVICE_ID="simulator")
     add_compile_definitions(CONFIG_TT_DEVICE_NAME="Simulator")
     add_compile_definitions(CONFIG_TT_DEVICE_VENDOR="")

--- a/Devices/btt-panda-touch/CMakeLists.txt
+++ b/Devices/btt-panda-touch/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 idf_component_register(
     SRCS ${SOURCE_FILES}
     INCLUDE_DIRS "source"
-    REQUIRES Tactility
+    REQUIRES TactilityKernel
 )

--- a/Devices/btt-panda-touch/device.properties
+++ b/Devices/btt-panda-touch/device.properties
@@ -12,8 +12,6 @@ hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 hardware.usbHostEnabled=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal
 
 display.size=5"

--- a/Devices/cyd-2432s024c/device.properties
+++ b/Devices/cyd-2432s024c/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.4"

--- a/Devices/cyd-2432s024r/device.properties
+++ b/Devices/cyd-2432s024r/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.4"

--- a/Devices/cyd-2432s028r/device.properties
+++ b/Devices/cyd-2432s028r/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/cyd-2432s028rv3/device.properties
+++ b/Devices/cyd-2432s028rv3/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/cyd-2432s032c/device.properties
+++ b/Devices/cyd-2432s032c/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=3.2"

--- a/Devices/cyd-3248s035c/device.properties
+++ b/Devices/cyd-3248s035c/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=3.5"

--- a/Devices/cyd-4848s040c/CMakeLists.txt
+++ b/Devices/cyd-4848s040c/CMakeLists.txt
@@ -2,5 +2,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 
 idf_component_register(
     SRCS ${SOURCE_FILES}
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/cyd-4848s040c/device.properties
+++ b/Devices/cyd-4848s040c/device.properties
@@ -10,8 +10,6 @@ hardware.spiRamMode=OCT
 hardware.spiRamSpeed=80M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=4"

--- a/Devices/cyd-8048s043c/CMakeLists.txt
+++ b/Devices/cyd-8048s043c/CMakeLists.txt
@@ -2,5 +2,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 
 idf_component_register(
     SRCS ${SOURCE_FILES}
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/cyd-8048s043c/device.properties
+++ b/Devices/cyd-8048s043c/device.properties
@@ -12,8 +12,6 @@ hardware.spiRamSpeed=80M
 hardware.esptoolFlashFreq=80M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=4.3"

--- a/Devices/cyd-e32r28t/device.properties
+++ b/Devices/cyd-e32r28t/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/cyd-e32r32p/device.properties
+++ b/Devices/cyd-e32r32p/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/elecrow-crowpanel-advance-28/device.properties
+++ b/Devices/elecrow-crowpanel-advance-28/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/elecrow-crowpanel-advance-35/device.properties
+++ b/Devices/elecrow-crowpanel-advance-35/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=3.5"

--- a/Devices/elecrow-crowpanel-advance-50/CMakeLists.txt
+++ b/Devices/elecrow-crowpanel-advance-50/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 idf_component_register(
     SRCS ${SOURCE_FILES}
     INCLUDE_DIRS "source"
-    REQUIRES Tactility
+    REQUIRES TactilityKernel
 )

--- a/Devices/elecrow-crowpanel-advance-50/device.properties
+++ b/Devices/elecrow-crowpanel-advance-50/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=5"

--- a/Devices/elecrow-crowpanel-basic-28/device.properties
+++ b/Devices/elecrow-crowpanel-basic-28/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/elecrow-crowpanel-basic-35/device.properties
+++ b/Devices/elecrow-crowpanel-basic-35/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=3.5"

--- a/Devices/elecrow-crowpanel-basic-50/CMakeLists.txt
+++ b/Devices/elecrow-crowpanel-basic-50/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 idf_component_register(
     SRCS ${SOURCE_FILES}
     INCLUDE_DIRS "source"
-    REQUIRES Tactility
+    REQUIRES TactilityKernel
 )

--- a/Devices/elecrow-crowpanel-basic-50/device.properties
+++ b/Devices/elecrow-crowpanel-basic-50/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=5.0"

--- a/Devices/es3c28p/device.properties
+++ b/Devices/es3c28p/device.properties
@@ -19,5 +19,3 @@ display.dpi=143
 lvgl.colorDepth=16
 
 storage.userDataLocation=SD
-
-dependencies.useDeprecatedHal=false

--- a/Devices/generic-esp32/device.properties
+++ b/Devices/generic-esp32/device.properties
@@ -7,6 +7,4 @@ hardware.target=ESP32
 hardware.flashSize=8MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal

--- a/Devices/generic-esp32c6/device.properties
+++ b/Devices/generic-esp32c6/device.properties
@@ -7,6 +7,4 @@ hardware.target=ESP32C6
 hardware.flashSize=8MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal

--- a/Devices/generic-esp32p4/device.properties
+++ b/Devices/generic-esp32p4/device.properties
@@ -7,6 +7,4 @@ hardware.target=ESP32P4
 hardware.flashSize=8MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal

--- a/Devices/generic-esp32s3/device.properties
+++ b/Devices/generic-esp32s3/device.properties
@@ -7,6 +7,4 @@ hardware.target=ESP32S3
 hardware.flashSize=8MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal

--- a/Devices/guition-jc1060p470ciwy/device.properties
+++ b/Devices/guition-jc1060p470ciwy/device.properties
@@ -11,8 +11,6 @@ hardware.spiRamSpeed=200M
 hardware.esptoolFlashFreq=80M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=7"

--- a/Devices/guition-jc2432w328c/CMakeLists.txt
+++ b/Devices/guition-jc2432w328c/CMakeLists.txt
@@ -2,5 +2,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 
 idf_component_register(
     SRCS ${SOURCE_FILES}
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/guition-jc2432w328c/device.properties
+++ b/Devices/guition-jc2432w328c/device.properties
@@ -7,8 +7,6 @@ hardware.target=ESP32
 hardware.flashSize=4MB
 hardware.spiRam=false
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/guition-jc8048w550c/CMakeLists.txt
+++ b/Devices/guition-jc8048w550c/CMakeLists.txt
@@ -2,5 +2,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 
 idf_component_register(
     SRCS ${SOURCE_FILES}
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/guition-jc8048w550c/device.properties
+++ b/Devices/guition-jc8048w550c/device.properties
@@ -11,8 +11,6 @@ hardware.spiRamSpeed=80M
 hardware.esptoolFlashFreq=80M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=5"

--- a/Devices/heltec-wifi-lora-32-v3/device.properties
+++ b/Devices/heltec-wifi-lora-32-v3/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal
 
 display.size=0.96"

--- a/Devices/lilygo-tdeck-max/device.properties
+++ b/Devices/lilygo-tdeck-max/device.properties
@@ -18,8 +18,6 @@ hardware.bluetooth=true
 # Internal until the SD card is verified working on this board; switch to SD then.
 storage.userDataLocation=Internal
 
-dependencies.useDeprecatedHal=false
-
 display.size=3.1"
 display.shape=rectangle
 display.dpi=128

--- a/Devices/lilygo-tdeck-plus/device.properties
+++ b/Devices/lilygo-tdeck-plus/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/lilygo-tdeck-plus/source/module.cpp
+++ b/Devices/lilygo-tdeck-plus/source/module.cpp
@@ -1,13 +1,13 @@
 #include <tactility/delay.h>
 #include <tactility/error.h>
 #include <tactility/log.h>
-#include <lvgl/lvgl.h>
 #include <tactility/module.h>
-
 #include <tactility/system_event.h>
 
 #include <Tactility/LogMessages.h>
 #include <Tactility/settings/TrackballSettings.h>
+
+#include <lvgl/lvgl.h>
 
 #include <lilygo/drivers/trackball.h>
 #include <lilygo/drivers/tdeck_power_on.h>

--- a/Devices/lilygo-tdeck-pro/device.properties
+++ b/Devices/lilygo-tdeck-pro/device.properties
@@ -17,8 +17,6 @@ hardware.bluetooth=true
 
 storage.userDataLocation=SD
 
-dependencies.useDeprecatedHal=false
-
 display.size=3.1"
 display.shape=rectangle
 display.dpi=128

--- a/Devices/lilygo-tdeck/device.properties
+++ b/Devices/lilygo-tdeck/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/lilygo-tdisplay-s3/device.properties
+++ b/Devices/lilygo-tdisplay-s3/device.properties
@@ -13,8 +13,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal
 
 display.size=1.9"

--- a/Devices/lilygo-tdisplay/CMakeLists.txt
+++ b/Devices/lilygo-tdisplay/CMakeLists.txt
@@ -2,5 +2,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 
 idf_component_register(
     SRCS ${SOURCE_FILES}
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/lilygo-tdisplay/device.properties
+++ b/Devices/lilygo-tdisplay/device.properties
@@ -10,8 +10,6 @@ hardware.flashSize=16MB
 hardware.spiRam=false
 hardware.esptoolFlashFreq=80M
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal
 
 display.size=1.14"

--- a/Devices/lilygo-tdongle-s3/CMakeLists.txt
+++ b/Devices/lilygo-tdongle-s3/CMakeLists.txt
@@ -2,5 +2,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 
 idf_component_register(
     SRCS ${SOURCE_FILES}
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/lilygo-tdongle-s3/device.properties
+++ b/Devices/lilygo-tdongle-s3/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=0.96"

--- a/Devices/lilygo-thmi/CMakeLists.txt
+++ b/Devices/lilygo-thmi/CMakeLists.txt
@@ -2,5 +2,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 
 idf_component_register(
     SRCS ${SOURCE_FILES}
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/lilygo-thmi/device.properties
+++ b/Devices/lilygo-thmi/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.8"

--- a/Devices/lilygo-tlora-pager/device.properties
+++ b/Devices/lilygo-tlora-pager/device.properties
@@ -13,8 +13,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=40M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2.33"

--- a/Devices/m5stack-cardputer-adv/device.properties
+++ b/Devices/m5stack-cardputer-adv/device.properties
@@ -10,8 +10,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=1.14"

--- a/Devices/m5stack-cardputer/device.properties
+++ b/Devices/m5stack-cardputer/device.properties
@@ -10,8 +10,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=1.14"

--- a/Devices/m5stack-core2/device.properties
+++ b/Devices/m5stack-core2/device.properties
@@ -12,8 +12,6 @@ hardware.esptoolFlashFreq=80M
 
 storage.userDataLocation=SD
 
-dependencies.useDeprecatedHal=false
-
 display.size=2"
 display.shape=rectangle
 display.dpi=200

--- a/Devices/m5stack-cores3/device.properties
+++ b/Devices/m5stack-cores3/device.properties
@@ -14,8 +14,6 @@ hardware.bluetooth=true
 
 storage.userDataLocation=Internal
 
-dependencies.useDeprecatedHal=false
-
 display.size=2"
 display.shape=rectangle
 display.dpi=200

--- a/Devices/m5stack-papers3/device.properties
+++ b/Devices/m5stack-papers3/device.properties
@@ -15,8 +15,6 @@ hardware.bluetooth=true
 
 storage.userDataLocation=SD
 
-dependencies.useDeprecatedHal=false
-
 display.size=4.7"
 display.shape=rectangle
 display.dpi=235

--- a/Devices/m5stack-stackchan/device.properties
+++ b/Devices/m5stack-stackchan/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=2"

--- a/Devices/m5stack-stickc-plus2/CMakeLists.txt
+++ b/Devices/m5stack-stickc-plus2/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 idf_component_register(
     SRCS ${SOURCE_FILES}
     INCLUDE_DIRS "source"
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/m5stack-stickc-plus2/CMakeLists.txt
+++ b/Devices/m5stack-stickc-plus2/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 idf_component_register(
     SRCS ${SOURCE_FILES}
     INCLUDE_DIRS "source"
-    REQUIRES TactilityKernel
+    REQUIRES TactilityKernel driver
 )

--- a/Devices/m5stack-stickc-plus2/device.properties
+++ b/Devices/m5stack-stickc-plus2/device.properties
@@ -10,8 +10,6 @@ hardware.spiRamMode=QUAD
 hardware.spiRamSpeed=80M
 hardware.esptoolFlashFreq=80M
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal
 
 display.size=1.14"

--- a/Devices/m5stack-sticks3/device.properties
+++ b/Devices/m5stack-sticks3/device.properties
@@ -12,8 +12,6 @@ hardware.esptoolFlashFreq=80M
 hardware.tinyUsb=true
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal
 
 display.size=1.14"

--- a/Devices/m5stack-tab5/CMakeLists.txt
+++ b/Devices/m5stack-tab5/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SOURCE_FILES Source/*.c*)
 idf_component_register(
     SRCS ${SOURCE_FILES}
     INCLUDE_DIRS "Source"
-    REQUIRES Tactility esp_lvgl_port esp_lcd esp_lcd_ili9881c esp_lcd_st7123 esp_lcd_touch_st7123 esp_lcd_touch_gt911 driver esp_driver_i2c vfs fatfs ina226-module ili9881c-module st7123-module gt911-module
+    REQUIRES TactilityKernel lvgl-module ina226-module ili9881c-module st7123-module gt911-module
 )

--- a/Devices/unphone/device.properties
+++ b/Devices/unphone/device.properties
@@ -10,8 +10,6 @@ hardware.spiRamMode=OCT
 hardware.spiRamSpeed=80M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=3.5"

--- a/Devices/waveshare-esp32-s3-geek/CMakeLists.txt
+++ b/Devices/waveshare-esp32-s3-geek/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 idf_component_register(
     SRCS ${SOURCE_FILES}
     INCLUDE_DIRS "source"
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/waveshare-esp32-s3-geek/device.properties
+++ b/Devices/waveshare-esp32-s3-geek/device.properties
@@ -14,8 +14,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=1.14"

--- a/Devices/waveshare-s3-lcd-13/CMakeLists.txt
+++ b/Devices/waveshare-s3-lcd-13/CMakeLists.txt
@@ -2,5 +2,5 @@ file(GLOB_RECURSE SOURCE_FILES source/*.c*)
 
 idf_component_register(
     SRCS ${SOURCE_FILES}
-    REQUIRES TactilityKernel driver
+    REQUIRES TactilityKernel
 )

--- a/Devices/waveshare-s3-lcd-13/device.properties
+++ b/Devices/waveshare-s3-lcd-13/device.properties
@@ -14,8 +14,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=1.3"

--- a/Devices/waveshare-s3-touch-lcd-128/device.properties
+++ b/Devices/waveshare-s3-touch-lcd-128/device.properties
@@ -14,8 +14,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=Internal
 
 display.size=1.28"

--- a/Devices/waveshare-s3-touch-lcd-147/device.properties
+++ b/Devices/waveshare-s3-touch-lcd-147/device.properties
@@ -13,8 +13,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=1.47"

--- a/Devices/waveshare-s3-touch-lcd-43/device.properties
+++ b/Devices/waveshare-s3-touch-lcd-43/device.properties
@@ -13,8 +13,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=120M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=4.3"

--- a/Devices/wireless-tag-wt32-sc01-plus/device.properties
+++ b/Devices/wireless-tag-wt32-sc01-plus/device.properties
@@ -12,8 +12,6 @@ hardware.tinyUsb=true
 hardware.esptoolFlashFreq=80M
 hardware.bluetooth=true
 
-dependencies.useDeprecatedHal=false
-
 storage.userDataLocation=SD
 
 display.size=3.5"

--- a/Firmware/Kconfig
+++ b/Firmware/Kconfig
@@ -77,12 +77,6 @@ menu "Tactility App"
     config TT_TDECK_WORKAROUND
         bool "Temporary work-around until we fix the T-Deck keyboard and trackball settings"
         default n
-    config TT_USE_DEPRECATED_HAL
-        bool "When set to false, it ensures an empty tt::hal::hardwareConfig is made automatically"
-        default y
-        help
-            This allows for migrating projects that don't use the old HAL.
-            When set to 'n', the project has an option to not depend on Tactility and can depend on TactilityKernel instead.
     choice TT_USER_DATA_LOCATION
         prompt "User Data Location"
         default TT_USER_DATA_LOCATION_INTERNAL

--- a/device.py
+++ b/device.py
@@ -169,13 +169,6 @@ def write_core_variables(output_file, device_properties: dict):
         output_file.write("CONFIG_ESP_WIFI_RX_IRAM_OPT=n\n")
         output_file.write("CONFIG_HEAP_PLACE_FUNCTION_INTO_FLASH=y\n")
         output_file.write("CONFIG_RINGBUF_PLACE_ISR_FUNCTIONS_INTO_FLASH=y\n")
-    # Usage of tt::hal can be disabled to simplify dependency wiring (device depends on TactilityKernel instead of Tactility)
-    use_deprecated_hal = get_property_or_none(device_properties, "dependencies.useDeprecatedHal")
-    if use_deprecated_hal is None or use_deprecated_hal.lower() == "true":
-        output_file.write("CONFIG_TT_USE_DEPRECATED_HAL=y\n")
-    else:
-        output_file.write("CONFIG_TT_USE_DEPRECATED_HAL=n\n")
-
 def write_flash_variables(output_file, device_properties: dict):
     flash_size = get_property_or_exit(device_properties, "hardware.flashSize")
     if not flash_size.endswith("MB"):


### PR DESCRIPTION
- Updated dependencies in `Devices/`: remove unused ones, update incorrect ones
- Removed `dependencies.useDeprecatedHal` from device properties (and related scripting/code)