### PR TITLE
fix(gdeq031t10): reset the panel at the start of a full init

### DIFF
--- a/Drivers/gdeq031t10-module/source/gdeq031t10.cpp
+++ b/Drivers/gdeq031t10-module/source/gdeq031t10.cpp
@@ -132,6 +132,11 @@ static void hardware_reset(Gdeq031t10Internal* internal) {
 }
 
 static bool init_full(Gdeq031t10Internal* internal, bool mirror_180) {
+    // The reset pulse restores register defaults, which the init sequence below assumes:
+    // a cold-booted controller never drives BUSY ready after CMD_POWER_ON without it, a
+    // mode change needs partial mode's lingering VCOM/data-interval setting cleared, and
+    // waking from deep sleep is only possible by toggling RST.
+    hardware_reset(internal);
     bool ok = write_command(internal, CMD_PANEL_SETTING);
     ok = ok && write_data_byte(internal, mirror_180 ? 0x13 : 0x1F);
     ok = ok && write_command(internal, CMD_POWER_ON);


### PR DESCRIPTION
Fixes #602.

The kernel-driver port in #582 dropped the reset pulse that the pre-migration driver issued at the top of its full init:

```cpp
bool Gdeq031t10Display::initFull() {
    reset();
    bool ok = writeCommand(CMD_PANEL_SETTING);
    ...
```

`hardware_reset()` survived the port but is only reachable from the `reset()` display op, which nothing calls on the start path. Without the pulse a cold-booted controller never drives BUSY ready after `CMD_POWER_ON`, so `display` fails to start, and since a failed device start aborts `kernel_init`, the LilyGO T-Deck Max does not boot at all on current main.

Two comments in the driver already assume the pulse is still there, so this also restores deep-sleep wake and the register-default reset that a waveform-mode change relies on:

- `gdeq031t10_disp_on_off()`: "Toggling RST (in init_full) also wakes the panel from deep sleep."
- A mode change needs partial mode's lingering VCOM/data-interval setting cleared, which was the original reason `reset()` lived in `initFull()` rather than at construction.

## Verification

Hardware, LilyGO T-Deck Max. Before:

```
I (1566) device: start display
E (6571) GDEQ031T10: Timed out waiting for panel BUSY
E (6571) GDEQ031T10: Full init failed
E (6573) kernel: kernel_init failed to construct+add+start device: display (gooddisplay,gdeq031t10)
E (6582) Tactility: Failed to initialize kernel
```

After:

```
I (1566) device: start display
I (1631) GDEQ031T10: waited 42 ms until not busy
I (1631) driver: bound gdeq031t10 to display
I (1631) kernel: init done
```

Boot completes, the SD card mounts, and refreshes run normally (`draw_bitmap: refresh_full`, `waited 1014 ms until not busy`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device initialization by resetting hardware before the full startup sequence.
  * Ensured reliable recovery from deep sleep and cleared lingering settings from partial operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->