### PR TITLE
fix(gdeq031t10): only commit the shadow after the panel confirms

### DIFF
--- a/Drivers/gdeq031t10-module/source/gdeq031t10.cpp
+++ b/Drivers/gdeq031t10-module/source/gdeq031t10.cpp
@@ -226,9 +226,9 @@ static void refresh_full(Gdeq031t10Internal* internal, bool mirror_180, enum Gde
         return;
     }
 
-    LOG_I(TAG, "memcpy render_bitmap -> shadow_buffer");
-    std::memcpy(internal->shadow_framebuffer, render_bitmap, FRAMEBUFFER_SIZE);
-    if (!write_command(internal, CMD_DATA_START_NEW) || !write_data(internal, internal->shadow_framebuffer, FRAMEBUFFER_SIZE)) {
+    // Sent straight from the render buffer: the shadow still has to describe what the panel
+    // is showing right now until this refresh is confirmed below.
+    if (!write_command(internal, CMD_DATA_START_NEW) || !write_data(internal, render_bitmap, FRAMEBUFFER_SIZE)) {
         LOG_E(TAG, "Failed to send new frame data");
         return;
     }
@@ -238,7 +238,13 @@ static void refresh_full(Gdeq031t10Internal* internal, bool mirror_180, enum Gde
         return;
     }
     delay_millis(1); // datasheet requires >=200us settle before polling BUSY
-    if (!wait_while_busy(internal)) {
+    if (wait_while_busy(internal)) {
+        // Confirmed: the panel now shows this frame, so the shadow can too.
+        std::memcpy(internal->shadow_framebuffer, render_bitmap, FRAMEBUFFER_SIZE);
+    } else {
+        // Leave the shadow alone: the panel did not confirm, so it still holds the previous
+        // frame. Claiming otherwise would make the next update compute its transitions from
+        // content the panel never displayed, and hide the difference from the change scan.
         LOG_E(TAG, "Full refresh did not complete");
     }
 
@@ -295,15 +301,13 @@ static void refresh_window(Gdeq031t10Internal* internal, bool mirror_180, const 
         return;
     }
 
-    // New region: render data, and update the shadow for this region as we go.
+    // New region: render data only. The shadow still has to describe what the panel is
+    // showing until this refresh is confirmed below.
     n = 0;
     for (int row = first_row; row <= last_row; row++) {
         const size_t base = static_cast<size_t>(row) * BYTES_PER_ROW + first_byte_col;
-        for (int c = 0; c < width_bytes; c++) {
-            const uint8_t value = render_bitmap[base + c];
-            internal->region_buffer[n++] = value;
-            internal->shadow_framebuffer[base + c] = value;
-        }
+        std::memcpy(&internal->region_buffer[n], &render_bitmap[base], width_bytes);
+        n += width_bytes;
     }
     if (!write_command(internal, CMD_DATA_START_NEW) || !write_data(internal, internal->region_buffer, n)) {
         LOG_E(TAG, "Failed to send new window data");
@@ -311,13 +315,24 @@ static void refresh_window(Gdeq031t10Internal* internal, bool mirror_180, const 
         return;
     }
 
+    bool confirmed = false;
     if (write_command(internal, CMD_DISPLAY_REFRESH)) {
         delay_millis(1);
-        if (!wait_while_busy(internal)) {
+        confirmed = wait_while_busy(internal);
+        if (!confirmed) {
             LOG_E(TAG, "Window refresh did not complete");
         }
     } else {
         LOG_E(TAG, "Failed to trigger window refresh");
+    }
+
+    // Only commit the region the panel confirmed; on failure the shadow keeps describing
+    // the previous content, so the next change scan still sees this region as dirty.
+    if (confirmed) {
+        for (int row = first_row; row <= last_row; row++) {
+            const size_t base = static_cast<size_t>(row) * BYTES_PER_ROW + first_byte_col;
+            std::memcpy(&internal->shadow_framebuffer[base], &render_bitmap[base], width_bytes);
+        }
     }
     write_command(internal, CMD_PARTIAL_OUT);
 }


### PR DESCRIPTION
Fixes #606.

`shadow_framebuffer` is the driver's record of what the panel is currently showing. Both refresh paths update it *before* the panel confirms the refresh completed, so any failure leaves it describing content that was never displayed.

`refresh_full()` copied the render buffer into the shadow, then used the shadow as the source for the new-data write. That copy happened before the `CMD_DISPLAY_REFRESH` trigger and before `wait_while_busy()`, so a failed trigger or a BUSY timeout still left the shadow updated.

`refresh_window()` had the same shape: it wrote the shadow inside the gather loop that fills `region_buffer`, before the new-data write and before the confirm.

The consequences compound, because the shadow is not just a change-detection cache:

- It is sent to the controller as `CMD_DATA_START_OLD`, so a wrong shadow makes the controller compute per-pixel transitions from an image the panel was never showing.
- `draw_bitmap()` diffs against it to find the changed bounding box, so a region that "matches" a wrong shadow is treated as clean and never redrawn. The panel then holds stale content indefinitely while the UI believes it was painted.

## Change

Commit the shadow only after the panel confirms:

- `refresh_full()` sends new data straight from `render_bitmap` and copies into the shadow only once `wait_while_busy()` returns true. This also removes a full-framebuffer copy from the path.
- `refresh_window()` gathers `region_buffer` from `render_bitmap` only, and copies the window into the shadow after the confirm.

On failure the shadow keeps describing the previous content, so the next change scan still sees the region as dirty and repaints it.

`refresh_window()` is currently unreachable (`draw_bitmap()` sets `force_full_refresh` unconditionally as a work-around), but it is fixed here so the behaviour is correct when partial updates are re-enabled.

No functional change on the success path.

## Testing

Built and run on a T-Deck Max (with #603 applied so the board boots): normal operation is unaffected, menus render and navigate as before.

Worth being straight about the limits of that: the success path is unchanged by design, so this confirms nothing is broken rather than demonstrating the fix. The bug only bites when a refresh fails, which is difficult to provoke deliberately. The reasoning is in #606.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display refresh reliability by updating rendered content only after the panel confirms a successful refresh.
  * Preserved the previous display state when a refresh fails or does not complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->